### PR TITLE
Everywhere: Prefer = default; to define [con,des]tructors

### DIFF
--- a/.devcontainer/features/serenity/devcontainer-feature.json
+++ b/.devcontainer/features/serenity/devcontainer-feature.json
@@ -11,9 +11,11 @@
                 16,
                 17,
                 18,
+                19,
+                20,
                 "trunk"
             ],
-            "default": 18,
+            "default": 20,
             "description": "Select LLVM compiler version to use"
         },
         "enable_ladybird": {

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,18 +24,18 @@ runs:
         set -e
 
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main'
 
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 
         sudo apt-get update
-        sudo apt-get install ccache clang-18 clang++-18 clang-format-18 lld-18 gcc-13 g++-13 libstdc++-13-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev libclang-18-dev
+        sudo apt-get install ccache clang-20 clang++-20 clang-format-20 lld-20 gcc-13 g++-13 libstdc++-13-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev libclang-20-dev
 
         sudo apt-get remove clang-{13,14,15} clang++-{13,14,15} libclang-{13,14,15}-dev llvm-{13,14,15}
-        sudo apt-get install clang-18 clang++-18 llvm-18 llvm-18-dev
+        sudo apt-get install clang-20 clang++-20 llvm-20 llvm-20-dev
 
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
@@ -63,14 +63,14 @@ runs:
         set -e
 
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main'
 
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 
         sudo apt-get update
         sudo apt-get remove clang-{13,14,15} clang++-{13,14,15} libclang-{13,14,15}-dev llvm-{13,14,15}
-        sudo apt-get install clang-format-18 ccache e2fsprogs gcc-13 g++-13 libstdc++-13-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja libegl1-mesa-dev
-        sudo apt-get install clang-18 clang++-18 llvm-18 llvm-18-dev
+        sudo apt-get install clang-format-20 ccache e2fsprogs gcc-13 g++-13 libstdc++-13-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja libegl1-mesa-dev
+        sudo apt-get install clang-20 clang++-20 llvm-20 llvm-20-dev
 
     - name: Enable KVM group perms
       if: ${{ inputs.os == 'Serenity' }}

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           if ${{ inputs.os_name == 'Linux' }} ; then
             if ${{ inputs.toolchain == 'Clang' }} ; then
-              echo "host_cc=clang-18" >> "$GITHUB_OUTPUT"
-              echo "host_cxx=clang++-18" >> "$GITHUB_OUTPUT"
+              echo "host_cc=clang-20" >> "$GITHUB_OUTPUT"
+              echo "host_cxx=clang++-20" >> "$GITHUB_OUTPUT"
             elif ${{ inputs.toolchain == 'GNU' }} ; then
               echo "host_cc=gcc-13" >> "$GITHUB_OUTPUT"
               echo "host_cxx=g++-13" >> "$GITHUB_OUTPUT"

--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -46,13 +46,13 @@ namespace AK {
  */
 
 namespace DistinctNumericFeature {
-enum Arithmetic {};
-enum CastToBool {};
-enum CastToUnderlying {};
-enum Comparison {};
-enum Flags {};
-enum Increment {};
-enum Shift {};
+enum Arithmetic { };
+enum CastToBool { };
+enum CastToUnderlying { };
+enum Comparison { };
+enum Flags { };
+enum Increment { };
+enum Shift { };
 };
 
 template<typename T, typename X, typename... Opts>

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -24,9 +24,9 @@ class IntrusiveListNode;
 
 struct ExtractIntrusiveListTypes {
     template<typename V, typename Container, typename T>
-    static V value(IntrusiveListNode<V, Container> T::*x);
+    static V value(IntrusiveListNode<V, Container> T::* x);
     template<typename V, typename Container, typename T>
-    static Container container(IntrusiveListNode<V, Container> T::*x);
+    static Container container(IntrusiveListNode<V, Container> T::* x);
 };
 
 template<typename T, typename Container = RawPtr<T>>
@@ -37,14 +37,14 @@ class IntrusiveListStorage {
 private:
     friend class IntrusiveListNode<T, Container>;
 
-    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
+    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::* member>
     friend class IntrusiveList;
 
     SubstitutedIntrusiveListNode<T, Container>* m_first { nullptr };
     SubstitutedIntrusiveListNode<T, Container>* m_last { nullptr };
 };
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 class IntrusiveList {
     AK_MAKE_NONCOPYABLE(IntrusiveList);
     AK_MAKE_NONMOVABLE(IntrusiveList);
@@ -166,7 +166,7 @@ public:
     //       to be of equal types. so for now, just make the members public on clang.
 #if !defined(AK_COMPILER_CLANG)
 private:
-    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
+    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::* member>
     friend class ::AK::Detail::IntrusiveList;
 #endif
 
@@ -176,7 +176,7 @@ private:
     [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, Container, member>::Iterator::erase()
 {
     auto old = m_value;
@@ -185,26 +185,26 @@ inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, 
     return *this;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline IntrusiveList<T, Container, member>::~IntrusiveList()
 {
     clear();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::clear()
 {
     while (m_storage.m_first)
         m_storage.m_first->remove();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline bool IntrusiveList<T, Container, member>::is_empty() const
 {
     return m_storage.m_first == nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline size_t IntrusiveList<T, Container, member>::size_slow() const
 {
     size_t size = 0;
@@ -215,7 +215,7 @@ inline size_t IntrusiveList<T, Container, member>::size_slow() const
     return size;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::append(T& n)
 {
     remove(n);
@@ -234,7 +234,7 @@ inline void IntrusiveList<T, Container, member>::append(T& n)
         m_storage.m_first = &nnode;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::prepend(T& n)
 {
     remove(n);
@@ -253,7 +253,7 @@ inline void IntrusiveList<T, Container, member>::prepend(T& n)
         m_storage.m_last = &nnode;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::insert_before(T& bn, T& n)
 {
     remove(n);
@@ -275,7 +275,7 @@ inline void IntrusiveList<T, Container, member>::insert_before(T& bn, T& n)
         new_node.m_self.reference = &n;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::remove(T& n)
 {
     auto& nnode = n.*member;
@@ -283,20 +283,20 @@ inline void IntrusiveList<T, Container, member>::remove(T& n)
         nnode.remove();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline bool IntrusiveList<T, Container, member>::contains(T const& n) const
 {
     auto& nnode = n.*member;
     return nnode.m_storage == &m_storage;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::first() const
 {
     return m_storage.m_first ? node_to_value(*m_storage.m_first) : nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::take_first()
 {
     if (Container ptr = first()) {
@@ -306,7 +306,7 @@ inline Container IntrusiveList<T, Container, member>::take_first()
     return nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::take_last()
 {
     if (Container ptr = last()) {
@@ -316,13 +316,13 @@ inline Container IntrusiveList<T, Container, member>::take_last()
     return nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::last() const
 {
     return m_storage.m_last ? node_to_value(*m_storage.m_last) : nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T const* IntrusiveList<T, Container, member>::next(T const* current)
 {
     auto& nextnode = (current->*member).m_next;
@@ -330,7 +330,7 @@ inline T const* IntrusiveList<T, Container, member>::next(T const* current)
     return nextstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T const* IntrusiveList<T, Container, member>::prev(T const* current)
 {
     auto& prevnode = (current->*member).m_prev;
@@ -338,7 +338,7 @@ inline T const* IntrusiveList<T, Container, member>::prev(T const* current)
     return prevstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T* IntrusiveList<T, Container, member>::next(T* current)
 {
     auto& nextnode = (current->*member).m_next;
@@ -346,7 +346,7 @@ inline T* IntrusiveList<T, Container, member>::next(T* current)
     return nextstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T* IntrusiveList<T, Container, member>::prev(T* current)
 {
     auto& prevnode = (current->*member).m_prev;
@@ -354,25 +354,25 @@ inline T* IntrusiveList<T, Container, member>::prev(T* current)
     return prevstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::Iterator IntrusiveList<T, Container, member>::begin()
 {
     return m_storage.m_first ? Iterator(node_to_value(*m_storage.m_first)) : Iterator();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::ReverseIterator IntrusiveList<T, Container, member>::rbegin()
 {
     return m_storage.m_last ? ReverseIterator(node_to_value(*m_storage.m_last)) : ReverseIterator();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::ConstIterator IntrusiveList<T, Container, member>::begin() const
 {
     return m_storage.m_first ? ConstIterator(node_to_value(*m_storage.m_first)) : ConstIterator();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T* IntrusiveList<T, Container, member>::node_to_value(SubstitutedIntrusiveListNode<T, Container>& node)
 {
     // Note: A data member pointer is a 32-bit offset in the Windows ABI (both x86 and x86_64),
@@ -426,7 +426,7 @@ inline bool IntrusiveListNode<T, Container>::is_in_list() const
 // By default, intrusive lists cannot contain null entries anyway, so switch to RefPtr
 // and just make the user-facing functions deref the pointers.
 
-template<class T, SubstitutedIntrusiveListNode<T, NonnullRefPtr<T>> T::*member>
+template<class T, SubstitutedIntrusiveListNode<T, NonnullRefPtr<T>> T::* member>
 class IntrusiveList<T, NonnullRefPtr<T>, member> : public IntrusiveList<T, RefPtr<T>, member> {
 public:
     [[nodiscard]] NonnullRefPtr<T> first() const { return *IntrusiveList<T, RefPtr<T>, member>::first(); }
@@ -441,7 +441,7 @@ public:
 // By default, intrusive lists cannot contain null entries anyway, so switch to LockRefPtr
 // and just make the user-facing functions deref the pointers.
 
-template<class T, SubstitutedIntrusiveListNode<T, NonnullLockRefPtr<T>> T::*member>
+template<class T, SubstitutedIntrusiveListNode<T, NonnullLockRefPtr<T>> T::* member>
 class IntrusiveList<T, NonnullLockRefPtr<T>, member> : public IntrusiveList<T, LockRefPtr<T>, member> {
 public:
     [[nodiscard]] NonnullLockRefPtr<T> first() const { return *IntrusiveList<T, LockRefPtr<T>, member>::first(); }

--- a/AK/IntrusiveListRelaxedConst.h
+++ b/AK/IntrusiveListRelaxedConst.h
@@ -11,7 +11,7 @@
 namespace AK {
 namespace Detail {
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, IntrusiveListNode<T, Container> T::* member>
 class IntrusiveListRelaxedConst : public IntrusiveList<T, Container, member> {
     AK_MAKE_NONCOPYABLE(IntrusiveListRelaxedConst);
     AK_MAKE_NONMOVABLE(IntrusiveListRelaxedConst);

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -16,17 +16,17 @@ class IntrusiveRedBlackTreeNode;
 
 struct ExtractIntrusiveRedBlackTreeTypes {
     template<typename K, typename V, typename Container, typename T>
-    static K key(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    static K key(IntrusiveRedBlackTreeNode<K, V, Container> T::* x);
     template<typename K, typename V, typename Container, typename T>
-    static V value(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    static V value(IntrusiveRedBlackTreeNode<K, V, Container> T::* x);
     template<typename K, typename V, typename Container, typename T>
-    static Container container(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    static Container container(IntrusiveRedBlackTreeNode<K, V, Container> T::* x);
 };
 
 template<Integral K, typename V, typename Container = RawPtr<V>>
 using SubstitutedIntrusiveRedBlackTreeNode = IntrusiveRedBlackTreeNode<K, V, typename SubstituteIntrusiveContainerType<V, Container>::Type>;
 
-template<Integral K, typename V, typename Container, SubstitutedIntrusiveRedBlackTreeNode<K, V, Container> V::*member>
+template<Integral K, typename V, typename Container, SubstitutedIntrusiveRedBlackTreeNode<K, V, Container> V::* member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
 
 public:
@@ -200,7 +200,7 @@ public:
 
 #if !defined(AK_COMPILER_CLANG)
 private:
-    template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::*member>
+    template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::* member>
     friend class ::AK::Detail::IntrusiveRedBlackTree;
 #endif
 
@@ -211,7 +211,7 @@ private:
 // Specialise IntrusiveRedBlackTree for NonnullRefPtr
 // By default, red black trees cannot contain null entries anyway, so switch to RefPtr
 // and just make the user-facing functions deref the pointers.
-template<Integral K, typename V, SubstitutedIntrusiveRedBlackTreeNode<K, V, NonnullRefPtr<V>> V::*member>
+template<Integral K, typename V, SubstitutedIntrusiveRedBlackTreeNode<K, V, NonnullRefPtr<V>> V::* member>
 class IntrusiveRedBlackTree<K, V, NonnullRefPtr<V>, member> : public IntrusiveRedBlackTree<K, V, RefPtr<V>, member> {
 public:
     [[nodiscard]] NonnullRefPtr<V> find(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find(key).release_nonnull(); }

--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -49,7 +49,7 @@ inline void secure_zero(void* ptr, size_t size)
     // The memory barrier is here to avoid the compiler optimizing
     // away the memset when we rely on it for wiping secrets.
     asm volatile("" ::
-                     : "memory");
+            : "memory");
 }
 
 // Naive implementation of a constant time buffer comparison function.

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -42,7 +42,7 @@ public:
         Node()
         {
         }
-        virtual ~Node() {};
+        virtual ~Node() = default;
     };
 
 protected:

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -94,8 +94,8 @@ public:
     ~Result() = default;
 
     // For compatibility with TRY().
-    void value() {};
-    void release_value() {};
+    void value() { }
+    void release_value() { }
 
     ErrorType& error()
     {

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -110,9 +110,9 @@ inline constexpr bool IsFunction<Ret(Args...) const volatile> = true;
 template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args..., ...) const volatile> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...)&> = true;
+inline constexpr bool IsFunction<Ret(Args...) &> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...)&> = true;
+inline constexpr bool IsFunction<Ret(Args..., ...) &> = true;
 template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args...) const&> = true;
 template<class Ret, class... Args>

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -155,7 +155,7 @@ requires(IsIntegral<T>)
 {
     if (!is_constant_evaluated()) {
         asm volatile(""
-                     : "+r"(value));
+            : "+r"(value));
     }
 }
 
@@ -165,9 +165,9 @@ requires(!IsIntegral<T>)
 {
     if (!is_constant_evaluated()) {
         asm volatile(""
-                     :
-                     : "m"(value)
-                     : "memory");
+            :
+            : "m"(value)
+            : "memory");
     }
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 **Do:**
 
 -   Write in idiomatic SerenityOS C++23, using the `AK` containers in all code.
--   Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 18 or later) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-18.
+-   Conform to the project coding style found in [CodingStyle.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 20 or later) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/SerenityOS/serenity/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-20.
 -   Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 -   Split your changes into separate, atomic commits (i.e. A commit per feature or fix, where the build, tests and the system are all functioning).
 -   Make sure your commits are rebased on the master branch.

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 18 or later!**
+**Important: Make sure you use `clang-format` version 20 or later!**
 
 This document describes the coding style used for C++ code in the Serenity Operating System project. All new code should conform to this style.
 

--- a/Documentation/QtCreatorConfiguration.md
+++ b/Documentation/QtCreatorConfiguration.md
@@ -51,7 +51,7 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 ## Auto-Formatting
 
-You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 18, as some OSes will ship older clang-format versions by default.
+You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 20, as some OSes will ship older clang-format versions by default.
 
 -   In QtCreator, go to "Help > About Plugins…"
 -   Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -577,25 +577,25 @@ inline uintptr_t invoke(Function function)
 #        if ARCH(X86_64)
     uintptr_t result;
     asm volatile("syscall"
-                 : "=a"(result)
-                 : "a"(function)
-                 : "rcx", "r11", "memory");
+        : "=a"(result)
+        : "a"(function)
+        : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
     uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x8 asm("x8") = function;
     asm volatile("svc #0"
-                 : "=r"(x0)
-                 : "r"(x8)
-                 : "memory");
+        : "=r"(x0)
+        : "r"(x8)
+        : "memory");
     result = x0;
 #        elif ARCH(RISCV64)
     register uintptr_t a7 asm("a7") = function;
     register uintptr_t result asm("a0");
     asm volatile("ecall"
-                 : "=r"(result)
-                 : "r"(a7)
-                 : "memory");
+        : "=r"(result)
+        : "r"(a7)
+        : "memory");
 #        endif
     return result;
 }
@@ -606,27 +606,27 @@ inline uintptr_t invoke(Function function, T1 arg1)
 #        if ARCH(X86_64)
     uintptr_t result;
     asm volatile("syscall"
-                 : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1)
-                 : "rcx", "r11", "memory");
+        : "=a"(result)
+        : "a"(function), "d"((uintptr_t)arg1)
+        : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
     uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x1 asm("x1") = arg1;
     register uintptr_t x8 asm("x8") = function;
     asm volatile("svc #0"
-                 : "=r"(x0)
-                 : "r"(x1), "r"(x8)
-                 : "memory");
+        : "=r"(x0)
+        : "r"(x1), "r"(x8)
+        : "memory");
     result = x0;
 #        elif ARCH(RISCV64)
     register uintptr_t a0 asm("a0") = arg1;
     register uintptr_t a7 asm("a7") = function;
     register uintptr_t result asm("a0");
     asm volatile("ecall"
-                 : "=r"(result)
-                 : "0"(a0), "r"(a7)
-                 : "memory");
+        : "=r"(result)
+        : "0"(a0), "r"(a7)
+        : "memory");
 #        endif
     return result;
 }
@@ -637,9 +637,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
 #        if ARCH(X86_64)
     uintptr_t result;
     asm volatile("syscall"
-                 : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2)
-                 : "rcx", "r11", "memory");
+        : "=a"(result)
+        : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2)
+        : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
     uintptr_t result;
     register uintptr_t x0 asm("x0");
@@ -647,9 +647,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
     register uintptr_t x2 asm("x2") = arg2;
     register uintptr_t x8 asm("x8") = function;
     asm volatile("svc #0"
-                 : "=r"(x0)
-                 : "r"(x1), "r"(x2), "r"(x8)
-                 : "memory");
+        : "=r"(x0)
+        : "r"(x1), "r"(x2), "r"(x8)
+        : "memory");
     result = x0;
 #        elif ARCH(RISCV64)
     register uintptr_t a0 asm("a0") = arg1;
@@ -657,9 +657,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
     register uintptr_t a7 asm("a7") = function;
     register uintptr_t result asm("a0");
     asm volatile("ecall"
-                 : "=r"(result)
-                 : "0"(a0), "r"(a1), "r"(a7)
-                 : "memory");
+        : "=r"(result)
+        : "0"(a0), "r"(a1), "r"(a7)
+        : "memory");
 #        endif
     return result;
 }
@@ -670,9 +670,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
 #        if ARCH(X86_64)
     uintptr_t result;
     asm volatile("syscall"
-                 : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3)
-                 : "rcx", "r11", "memory");
+        : "=a"(result)
+        : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3)
+        : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
     uintptr_t result;
     register uintptr_t x0 asm("x0");
@@ -681,9 +681,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
     register uintptr_t x3 asm("x3") = arg3;
     register uintptr_t x8 asm("x8") = function;
     asm volatile("svc #0"
-                 : "=r"(x0)
-                 : "r"(x1), "r"(x2), "r"(x3), "r"(x8)
-                 : "memory");
+        : "=r"(x0)
+        : "r"(x1), "r"(x2), "r"(x3), "r"(x8)
+        : "memory");
     result = x0;
 #        elif ARCH(RISCV64)
     register uintptr_t a0 asm("a0") = arg1;
@@ -692,9 +692,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
     register uintptr_t a7 asm("a7") = function;
     register uintptr_t result asm("a0");
     asm volatile("ecall"
-                 : "=r"(result)
-                 : "0"(a0), "r"(a1), "r"(a2), "r"(a7)
-                 : "memory");
+        : "=r"(result)
+        : "0"(a0), "r"(a1), "r"(a2), "r"(a7)
+        : "memory");
 #        endif
     return result;
 }
@@ -705,9 +705,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
 #        if ARCH(X86_64)
     uintptr_t result;
     asm volatile("syscall"
-                 : "=a"(result)
-                 : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
-                 : "rcx", "r11", "memory");
+        : "=a"(result)
+        : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
+        : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
     uintptr_t result;
     register uintptr_t x0 asm("x0");
@@ -717,9 +717,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
     register uintptr_t x4 asm("x4") = arg4;
     register uintptr_t x8 asm("x8") = function;
     asm volatile("svc #0"
-                 : "=r"(x0)
-                 : "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x8)
-                 : "memory");
+        : "=r"(x0)
+        : "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x8)
+        : "memory");
     result = x0;
 #        elif ARCH(RISCV64)
     register uintptr_t a0 asm("a0") = arg1;
@@ -729,9 +729,9 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
     register uintptr_t a7 asm("a7") = function;
     register uintptr_t result asm("a0");
     asm volatile("ecall"
-                 : "=r"(result)
-                 : "0"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(a7)
-                 : "memory");
+        : "=r"(result)
+        : "0"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(a7)
+        : "memory");
 #        endif
     return result;
 }

--- a/Kernel/Arch/aarch64/ASM_wrapper.h
+++ b/Kernel/Arch/aarch64/ASM_wrapper.h
@@ -37,7 +37,7 @@ inline FlatPtr get_ttbr0_el1()
 {
     FlatPtr ttbr0_el1;
     asm volatile("mrs %[value], ttbr0_el1\n"
-                 : [value] "=r"(ttbr0_el1));
+        : [value] "=r"(ttbr0_el1));
     return ttbr0_el1;
 }
 
@@ -76,7 +76,7 @@ inline ExceptionLevel get_current_exception_level()
     u64 current_exception_level;
 
     asm volatile("mrs  %[value], CurrentEL"
-                 : [value] "=r"(current_exception_level));
+        : [value] "=r"(current_exception_level));
 
     current_exception_level = (current_exception_level >> 2) & 0x3;
     return static_cast<ExceptionLevel>(current_exception_level);
@@ -140,7 +140,7 @@ inline FlatPtr get_cache_line_size()
 {
     FlatPtr ctr_el0;
     asm volatile("mrs %[value], ctr_el0"
-                 : [value] "=r"(ctr_el0));
+        : [value] "=r"(ctr_el0));
     auto log2_size = (ctr_el0 >> 16) & 0xF;
     return 1 << log2_size;
 }
@@ -150,16 +150,16 @@ inline void flush_data_cache(FlatPtr start, size_t size)
     auto const cache_size = get_cache_line_size();
     for (FlatPtr addr = align_down_to(start, cache_size); addr < start + size; addr += cache_size)
         asm volatile("dc civac, %[addr]" ::[addr] "r"(addr)
-                     : "memory");
+            : "memory");
     asm volatile("dsb sy" ::
-                     : "memory");
+            : "memory");
 }
 
 inline FlatPtr get_mdscr_el1()
 {
     FlatPtr mdscr_el1;
     asm volatile("mrs %[value], mdscr_el1\n"
-                 : [value] "=r"(mdscr_el1));
+        : [value] "=r"(mdscr_el1));
     return mdscr_el1;
 }
 

--- a/Kernel/Arch/aarch64/MainIdRegister.cpp
+++ b/Kernel/Arch/aarch64/MainIdRegister.cpp
@@ -12,7 +12,7 @@ MainIdRegister::MainIdRegister()
 {
     unsigned int mrs;
     asm volatile("mrs %x0, MIDR_EL1"
-                 : "=r"(mrs));
+        : "=r"(mrs));
     m_value = mrs;
 }
 

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -39,7 +39,7 @@ struct alignas(u64) ID_AA64ISAR0_EL1 {
         ID_AA64ISAR0_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64ISAR0_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -71,7 +71,7 @@ struct alignas(u64) ID_AA64ISAR1_EL1 {
         ID_AA64ISAR1_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64ISAR1_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -102,7 +102,7 @@ struct alignas(u64) ID_AA64ISAR2_EL1 {
         ID_AA64ISAR2_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64ISAR2_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -134,7 +134,7 @@ struct alignas(u64) ID_AA64PFR0_EL1 {
         ID_AA64PFR0_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64PFR0_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -166,7 +166,7 @@ struct alignas(u64) ID_AA64PFR1_EL1 {
         ID_AA64PFR1_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64PFR1_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -187,7 +187,7 @@ struct alignas(u64) ID_AA64PFR2_EL1 {
         ID_AA64PFR2_EL1 feature_register;
 
         asm volatile("mrs %[value], s3_0_c0_c4_2" // encoded ID_AA64PFR2_EL1 register
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -212,7 +212,7 @@ struct alignas(u64) MPIDR_EL1 {
         MPIDR_EL1 affinity_register;
 
         asm volatile("mrs %[value], MPIDR_EL1"
-                     : [value] "=r"(affinity_register));
+            : [value] "=r"(affinity_register));
 
         return affinity_register;
     }
@@ -243,7 +243,7 @@ struct alignas(u64) ID_AA64MMFR0_EL1 {
         ID_AA64MMFR0_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64MMFR0_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -275,7 +275,7 @@ struct alignas(u64) ID_AA64MMFR1_EL1 {
         ID_AA64MMFR1_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64MMFR1_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -307,7 +307,7 @@ struct alignas(u64) ID_AA64MMFR2_EL1 {
         ID_AA64MMFR2_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64MMFR2_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -339,7 +339,7 @@ struct alignas(u64) ID_AA64MMFR3_EL1 {
         ID_AA64MMFR3_EL1 feature_register;
 
         asm volatile("mrs %[value], s3_0_c0_c7_3" // encoded ID_AA64MMFR3_EL1 register
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -359,7 +359,7 @@ struct alignas(u64) ID_AA64MMFR4_EL1 {
         ID_AA64MMFR4_EL1 feature_register;
 
         asm volatile("mrs %[value], s3_0_c0_c7_4" // encoded ID_AA64MMFR4_EL1 register
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -391,7 +391,7 @@ struct alignas(u64) ID_AA64SMFR0_EL1 {
         ID_AA64SMFR0_EL1 feature_register;
 
         asm volatile("mrs %[value], s3_0_c0_c4_5" // encoded ID_AA64SMFR0_EL1 register
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -422,7 +422,7 @@ struct alignas(u64) ID_AA64ZFR0_EL1 {
         ID_AA64ZFR0_EL1 feature_register;
 
         asm volatile("mrs %[value], s3_0_c0_c4_4" // encoded ID_AA64ZFR0_EL1 register
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -454,7 +454,7 @@ struct alignas(u64) ID_AA64DFR0_EL1 {
         ID_AA64DFR0_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64DFR0_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -481,7 +481,7 @@ struct alignas(u64) ID_AA64DFR1_EL1 {
         ID_AA64DFR1_EL1 feature_register;
 
         asm volatile("mrs %[value], ID_AA64DFR1_EL1"
-                     : [value] "=r"(feature_register));
+            : [value] "=r"(feature_register));
 
         return feature_register;
     }
@@ -499,7 +499,7 @@ struct alignas(u64) CNTFRQ_EL0 {
         CNTFRQ_EL0 frequency;
 
         asm volatile("mrs %[value], CNTFRQ_EL0"
-                     : [value] "=r"(frequency));
+            : [value] "=r"(frequency));
 
         return frequency;
     }
@@ -517,7 +517,7 @@ struct alignas(u64) CNTP_TVAL_EL0 {
         CNTP_TVAL_EL0 timer_value;
 
         asm volatile("mrs %[value], CNTP_TVAL_EL0"
-                     : [value] "=r"(timer_value));
+            : [value] "=r"(timer_value));
 
         return timer_value;
     }
@@ -542,7 +542,7 @@ struct alignas(u64) CNTP_CTL_EL0 {
         CNTP_CTL_EL0 control_register;
 
         asm volatile("mrs %[value], CNTP_CTL_EL0"
-                     : [value] "=r"(control_register));
+            : [value] "=r"(control_register));
 
         return control_register;
     }
@@ -564,7 +564,7 @@ struct alignas(u64) CNTPCT_EL0 {
         CNTPCT_EL0 physical_count;
 
         asm volatile("mrs %[value], CNTPCT_EL0"
-                     : [value] "=r"(physical_count));
+            : [value] "=r"(physical_count));
 
         return physical_count;
     }
@@ -582,7 +582,7 @@ struct alignas(u64) CNTV_TVAL_EL0 {
         CNTV_TVAL_EL0 timer_value;
 
         asm volatile("mrs %[value], CNTV_TVAL_EL0"
-                     : [value] "=r"(timer_value));
+            : [value] "=r"(timer_value));
 
         return timer_value;
     }
@@ -607,7 +607,7 @@ struct alignas(u64) CNTV_CTL_EL0 {
         CNTV_CTL_EL0 control_register;
 
         asm volatile("mrs %[value], CNTV_CTL_EL0"
-                     : [value] "=r"(control_register));
+            : [value] "=r"(control_register));
 
         return control_register;
     }
@@ -629,7 +629,7 @@ struct alignas(u64) CNTVCT_EL0 {
         CNTVCT_EL0 virtual_count;
 
         asm volatile("mrs %[value], CNTVCT_EL0"
-                     : [value] "=r"(virtual_count));
+            : [value] "=r"(virtual_count));
 
         return virtual_count;
     }
@@ -735,7 +735,7 @@ struct alignas(u64) TCR_EL1 {
         TCR_EL1 tcr_el1;
 
         asm volatile("mrs %[value], tcr_el1"
-                     : [value] "=r"(tcr_el1));
+            : [value] "=r"(tcr_el1));
 
         return tcr_el1;
     }
@@ -805,7 +805,7 @@ struct alignas(u64) SCTLR_EL1 {
         SCTLR_EL1 sctlr;
 
         asm volatile("mrs %[value], sctlr_el1"
-                     : [value] "=r"(sctlr));
+            : [value] "=r"(sctlr));
 
         return sctlr;
     }
@@ -907,7 +907,7 @@ struct alignas(u64) SCTLR_EL2 {
         SCTLR_EL2 sctlr;
 
         asm volatile("mrs %[value], sctlr_el2"
-                     : [value] "=r"(sctlr));
+            : [value] "=r"(sctlr));
 
         return sctlr;
     }
@@ -951,7 +951,7 @@ struct alignas(u64) MIDR_EL1 {
         MIDR_EL1 main_id_register;
 
         asm volatile("mrs %[value], MIDR_EL1"
-                     : [value] "=r"(main_id_register));
+            : [value] "=r"(main_id_register));
 
         return main_id_register;
     }
@@ -968,7 +968,7 @@ struct alignas(u64) AIDR_EL1 {
         AIDR_EL1 auxiliary_id_register;
 
         asm volatile("mrs %[value], AIDR_EL1"
-                     : [value] "=r"(auxiliary_id_register));
+            : [value] "=r"(auxiliary_id_register));
 
         return auxiliary_id_register;
     }
@@ -1033,7 +1033,7 @@ struct alignas(u64) HCR_EL2 {
         HCR_EL2 spsr;
 
         asm volatile("mrs %[value], hcr_el2"
-                     : [value] "=r"(spsr));
+            : [value] "=r"(spsr));
 
         return spsr;
     }
@@ -1089,7 +1089,7 @@ struct alignas(u64) SCR_EL3 {
         SCR_EL3 scr;
 
         asm volatile("mrs %[value], scr_el3"
-                     : [value] "=r"(scr));
+            : [value] "=r"(scr));
 
         return scr;
     }
@@ -1137,7 +1137,7 @@ struct alignas(u64) SPSR_EL1 {
         SPSR_EL1 spsr;
 
         asm volatile("mrs %[value], spsr_el1"
-                     : [value] "=r"(spsr));
+            : [value] "=r"(spsr));
 
         return spsr;
     }
@@ -1186,7 +1186,7 @@ struct alignas(u64) SPSR_EL2 {
         SPSR_EL2 spsr;
 
         asm volatile("mrs %[value], spsr_el2"
-                     : [value] "=r"(spsr));
+            : [value] "=r"(spsr));
 
         return spsr;
     }
@@ -1235,7 +1235,7 @@ struct alignas(u64) SPSR_EL3 {
         SPSR_EL3 spsr;
 
         asm volatile("mrs %[value], spsr_el3"
-                     : [value] "=r"(spsr));
+            : [value] "=r"(spsr));
 
         return spsr;
     }
@@ -1269,7 +1269,7 @@ struct ESR_EL1 {
         ESR_EL1 esr_el1;
 
         asm volatile("mrs %[value], esr_el1"
-                     : [value] "=r"(esr_el1));
+            : [value] "=r"(esr_el1));
 
         return esr_el1;
     }
@@ -1285,7 +1285,7 @@ struct FAR_EL1 {
         FAR_EL1 far_el1;
 
         asm volatile("mrs %[value], far_el1"
-                     : [value] "=r"(far_el1));
+            : [value] "=r"(far_el1));
 
         return far_el1;
     }
@@ -1537,7 +1537,7 @@ struct DAIF {
         DAIF daif;
 
         asm volatile("mrs %[value], daif"
-                     : [value] "=r"(daif));
+            : [value] "=r"(daif));
 
         return daif;
     }
@@ -1546,14 +1546,14 @@ struct DAIF {
     static inline void clear_I()
     {
         asm volatile("msr daifclr, #2" ::
-                         :);
+                :);
     }
 
     // Setting the I bit, causes interrupts to be disabled.
     static inline void set_I()
     {
         asm volatile("msr daifset, #2" ::
-                         :);
+                :);
     }
 };
 static_assert(sizeof(DAIF) == 8);
@@ -1572,7 +1572,7 @@ struct alignas(u64) NZCV {
     {
         NZCV nzcv;
         asm volatile("mrs %[value], nzcv"
-                     : [value] "=r"(nzcv));
+            : [value] "=r"(nzcv));
         return nzcv;
     }
 };
@@ -1587,7 +1587,7 @@ struct alignas(u64) PMCCNTR_EL0 {
     {
         PMCCNTR_EL0 pmccntr_el0;
         asm volatile("mrs %[value], pmccntr_el0"
-                     : [value] "=r"(pmccntr_el0));
+            : [value] "=r"(pmccntr_el0));
         return pmccntr_el0;
     }
 };

--- a/Kernel/Arch/aarch64/SafeMem.cpp
+++ b/Kernel/Arch/aarch64/SafeMem.cpp
@@ -70,9 +70,9 @@ safe_memset_ins:
 .global safe_memset_faulted
 safe_memset_faulted:
 )"
-                 : [dest_ptr] "+&r"(dest_ptr), [result] "+&r"(result), "+&r"(fault_at_in_x3)
-                 : [n] "r"(n), [c] "r"(c)
-                 : "memory", "x4", "cc");
+        : [dest_ptr] "+&r"(dest_ptr), [result] "+&r"(result), "+&r"(fault_at_in_x3)
+        : [n] "r"(n), [c] "r"(c)
+        : "memory", "x4", "cc");
     return result != 0;
 }
 
@@ -98,9 +98,9 @@ safe_strnlen_ins:
 .global safe_strnlen_faulted
 safe_strnlen_faulted:
 )"
-                 : [result] "+&r"(result), "+&r"(fault_at_in_x2)
-                 : [str] "r"(str), [max_n] "r"(max_n)
-                 : "memory", "w3", "cc");
+        : [result] "+&r"(result), "+&r"(fault_at_in_x2)
+        : [str] "r"(str), [max_n] "r"(max_n)
+        : "memory", "w3", "cc");
     return result;
 }
 
@@ -129,9 +129,9 @@ safe_memcpy_ins_2:
 .global safe_memcpy_faulted
 safe_memcpy_faulted:
 )"
-                 : [result] "+&r"(result), "+&r"(fault_at_in_x3)
-                 : [dest_ptr] "r"(dest_ptr), [src_ptr] "r"(src_ptr), [n] "r"(n)
-                 : "memory", "x4", "w5", "cc");
+        : [result] "+&r"(result), "+&r"(fault_at_in_x3)
+        : [dest_ptr] "r"(dest_ptr), [src_ptr] "r"(src_ptr), [n] "r"(n)
+        : "memory", "x4", "w5", "cc");
     return result != 0;
 }
 
@@ -163,9 +163,9 @@ safe_atomic_compare_exchange_relaxed_ins_2:
 .global safe_atomic_compare_exchange_relaxed_faulted
 safe_atomic_compare_exchange_relaxed_faulted:
 )"
-                 : [result] "=&r"(result), "+&r"(error)
-                 : [var_ptr] "r"(var), [expected_ptr] "r"(&expected), [desired] "r"(desired)
-                 : "memory", "w3", "w4", "w5", "cc");
+        : [result] "=&r"(result), "+&r"(error)
+        : [var_ptr] "r"(var), [expected_ptr] "r"(&expected), [desired] "r"(desired)
+        : "memory", "w3", "w4", "w5", "cc");
     if (error != 0)
         return {};
     return static_cast<bool>(result);
@@ -183,9 +183,9 @@ safe_atomic_load_relaxed_ins:
 .global safe_atomic_load_relaxed_faulted
 safe_atomic_load_relaxed_faulted:
 )"
-                 : [result] "=r"(result), "+r"(error)
-                 : [var_ptr] "r"(var)
-                 : "memory");
+        : [result] "=r"(result), "+r"(error)
+        : [var_ptr] "r"(var)
+        : "memory");
     if (error != 0)
         return {};
     return result;
@@ -209,9 +209,9 @@ safe_atomic_fetch_add_relaxed_ins_2:
 .global safe_atomic_fetch_add_relaxed_faulted
 safe_atomic_fetch_add_relaxed_faulted:
 )"
-                 : [result] "=&r"(result), "+&r"(error)
-                 : [val] "r"(val), [var_ptr] "r"(var)
-                 : "memory", "w2", "w3");
+        : [result] "=&r"(result), "+&r"(error)
+        : [val] "r"(val), [var_ptr] "r"(var)
+        : "memory", "w2", "w3");
     if (error != 0)
         return {};
     return result;
@@ -234,9 +234,9 @@ safe_atomic_exchange_relaxed_ins_2:
 .global safe_atomic_exchange_relaxed_faulted
 safe_atomic_exchange_relaxed_faulted:
 )"
-                 : [result] "=&r"(result), "+&r"(error)
-                 : [desired] "r"(desired), [var_ptr] "r"(var)
-                 : "memory", "w2");
+        : [result] "=&r"(result), "+&r"(error)
+        : [desired] "r"(desired), [var_ptr] "r"(var)
+        : "memory", "w2");
     if (error != 0)
         return {};
     return result;
@@ -253,9 +253,9 @@ safe_atomic_store_relaxed_ins:
 .global safe_atomic_store_relaxed_faulted
 safe_atomic_store_relaxed_faulted:
 )"
-                 : "+r"(error)
-                 : [desired] "r"(desired), [var_ptr] "r"(var)
-                 : "memory");
+        : "+r"(error)
+        : [desired] "r"(desired), [var_ptr] "r"(var)
+        : "memory");
     return error == 0;
 }
 

--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -47,8 +47,8 @@ ALWAYS_INLINE FlatPtr read()
 {
     FlatPtr ret;
     asm volatile("csrr %0, %1"
-                 : "=r"(ret)
-                 : "i"(address));
+        : "=r"(ret)
+        : "i"(address));
     return ret;
 }
 
@@ -63,8 +63,8 @@ ALWAYS_INLINE FlatPtr read_and_set_bits(FlatPtr bit_mask)
 {
     FlatPtr ret;
     asm volatile("csrrs %0, %1, %2"
-                 : "=r"(ret)
-                 : "i"(address), "Kr"(bit_mask));
+        : "=r"(ret)
+        : "i"(address), "Kr"(bit_mask));
     return ret;
 }
 

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -54,7 +54,7 @@ static void store_vector_state(FPUState& fpu_state)
 
     .option pop
     )" ::"r"(fpu_state.v)
-                 : "t0", "memory");
+        : "t0", "memory");
 }
 
 static void load_vector_state(FPUState const& fpu_state)
@@ -84,7 +84,7 @@ static void load_vector_state(FPUState const& fpu_state)
 
     .option pop
     )" ::"r"(fpu_state.v)
-                 : "t0", "memory");
+        : "t0", "memory");
 
     RISCV64::CSR::write<RISCV64::CSR::Address::VSTART_>(fpu_state.vstart);
     RISCV64::CSR::write<RISCV64::CSR::Address::VCSR>(fpu_state.vcsr);
@@ -230,9 +230,9 @@ void ProcessorBase<T>::flush_tlb_local(VirtualAddress vaddr, size_t page_count)
     auto addr = vaddr.get();
     while (page_count > 0) {
         asm volatile("sfence.vma %0"
-                     :
-                     : "r"(addr)
-                     : "memory");
+            :
+            : "r"(addr)
+            : "memory");
         addr += PAGE_SIZE;
         page_count--;
     }

--- a/Kernel/Arch/riscv64/SBI.cpp
+++ b/Kernel/Arch/riscv64/SBI.cpp
@@ -24,9 +24,9 @@ static SBIErrorOr<long> sbi_ecall0(EID extension_id, u32 function_id)
     register unsigned long a6 asm("a6") = function_id;
     register unsigned long a7 asm("a7") = to_underlying(extension_id);
     asm volatile("ecall"
-                 : "=r"(a0), "=r"(a1)
-                 : "r"(a6), "r"(a7)
-                 : "memory");
+        : "=r"(a0), "=r"(a1)
+        : "r"(a6), "r"(a7)
+        : "memory");
     if (a0 == to_underlying(SBIError::Success))
         return static_cast<long>(a1);
 
@@ -40,9 +40,9 @@ static SBIErrorOr<long> sbi_ecall1(EID extension_id, u32 function_id, unsigned l
     register unsigned long a6 asm("a6") = function_id;
     register unsigned long a7 asm("a7") = to_underlying(extension_id);
     asm volatile("ecall"
-                 : "+r"(a0), "=r"(a1)
-                 : "r"(a0), "r"(a6), "r"(a7)
-                 : "memory");
+        : "+r"(a0), "=r"(a1)
+        : "r"(a0), "r"(a6), "r"(a7)
+        : "memory");
     if (a0 == to_underlying(SBIError::Success))
         return static_cast<long>(a1);
 
@@ -56,9 +56,9 @@ static SBIErrorOr<long> sbi_ecall2(EID extension_id, u32 function_id, unsigned l
     register unsigned long a6 asm("a6") = function_id;
     register unsigned long a7 asm("a7") = to_underlying(extension_id);
     asm volatile("ecall"
-                 : "+r"(a0), "+r"(a1)
-                 : "r"(a0), "r"(a1), "r"(a6), "r"(a7)
-                 : "memory");
+        : "+r"(a0), "+r"(a1)
+        : "r"(a0), "r"(a1), "r"(a6), "r"(a7)
+        : "memory");
     if (a0 == to_underlying(SBIError::Success))
         return static_cast<long>(a1);
 
@@ -112,9 +112,9 @@ static long sbi_legacy_ecall0(LegacyEID extension_id)
     register unsigned long a0 asm("a0");
     register unsigned long a7 asm("a7") = to_underlying(extension_id);
     asm volatile("ecall"
-                 : "=r"(a0)
-                 : "r"(a7)
-                 : "memory");
+        : "=r"(a0)
+        : "r"(a7)
+        : "memory");
     return static_cast<long>(a0);
 }
 
@@ -123,9 +123,9 @@ static long sbi_legacy_ecall1(LegacyEID extension_id, unsigned long arg0)
     register unsigned long a0 asm("a0") = arg0;
     register unsigned long a7 asm("a7") = to_underlying(extension_id);
     asm volatile("ecall"
-                 : "+r"(a0)
-                 : "r"(a0), "r"(a7)
-                 : "memory");
+        : "+r"(a0)
+        : "r"(a0), "r"(a7)
+        : "memory");
     return static_cast<long>(a0);
 }
 

--- a/Kernel/Arch/riscv64/SafeMem.cpp
+++ b/Kernel/Arch/riscv64/SafeMem.cpp
@@ -162,9 +162,9 @@ safe_atomic_compare_exchange_relaxed_ins_2:
 .global safe_atomic_compare_exchange_relaxed_faulted
 safe_atomic_compare_exchange_relaxed_faulted:
 )"
-                 : [result] "=&r"(result), "+&r"(error)
-                 : [var_ptr] "r"(var), [expected_ptr] "r"(&expected), [desired] "r"(desired)
-                 : "memory", "t0", "t1", "t2");
+        : [result] "=&r"(result), "+&r"(error)
+        : [var_ptr] "r"(var), [expected_ptr] "r"(&expected), [desired] "r"(desired)
+        : "memory", "t0", "t1", "t2");
     if (error != 0)
         return {};
     return static_cast<bool>(result);
@@ -182,9 +182,9 @@ safe_atomic_load_relaxed_ins:
 .global safe_atomic_load_relaxed_faulted
 safe_atomic_load_relaxed_faulted:
 )"
-                 : [result] "=r"(result), "+r"(error)
-                 : [var_ptr] "r"(var)
-                 : "memory");
+        : [result] "=r"(result), "+r"(error)
+        : [var_ptr] "r"(var)
+        : "memory");
     if (error != 0)
         return {};
     return result;
@@ -202,9 +202,9 @@ safe_atomic_fetch_add_relaxed_ins:
 .global safe_atomic_fetch_add_relaxed_faulted
 safe_atomic_fetch_add_relaxed_faulted:
 )"
-                 : [result] "=r"(result), "+r"(error)
-                 : [val] "r"(val), [var_ptr] "r"(var)
-                 : "memory");
+        : [result] "=r"(result), "+r"(error)
+        : [val] "r"(val), [var_ptr] "r"(var)
+        : "memory");
     if (error != 0)
         return {};
     return result;
@@ -222,9 +222,9 @@ safe_atomic_exchange_relaxed_ins:
 .global safe_atomic_exchange_relaxed_faulted
 safe_atomic_exchange_relaxed_faulted:
 )"
-                 : [result] "=r"(result), "+r"(error)
-                 : [desired] "r"(desired), [var_ptr] "r"(var)
-                 : "memory");
+        : [result] "=r"(result), "+r"(error)
+        : [desired] "r"(desired), [var_ptr] "r"(var)
+        : "memory");
     if (error != 0)
         return {};
     return result;
@@ -241,9 +241,9 @@ safe_atomic_store_relaxed_ins:
 .global safe_atomic_store_relaxed_faulted
 safe_atomic_store_relaxed_faulted:
 )"
-                 : "+r"(error)
-                 : [desired] "r"(desired), [var_ptr] "r"(var)
-                 : "memory");
+        : "+r"(error)
+        : [desired] "r"(desired), [var_ptr] "r"(var)
+        : "memory");
     return error == 0;
 }
 

--- a/Kernel/Arch/x86_64/ASM_wrapper.cpp
+++ b/Kernel/Arch/x86_64/ASM_wrapper.cpp
@@ -18,8 +18,8 @@ UNMAP_AFTER_INIT u64 read_xcr0()
 {
     u32 eax, edx;
     asm volatile("xgetbv"
-                 : "=a"(eax), "=d"(edx)
-                 : "c"(XCR_XFEATURE_ENABLED_MASK));
+        : "=a"(eax), "=d"(edx)
+        : "c"(XCR_XFEATURE_ENABLED_MASK));
     return eax + ((u64)edx << 32);
 }
 
@@ -35,7 +35,7 @@ void stac()
     if (!Processor::current().has_feature(CPUFeature::SMAP))
         return;
     asm volatile("stac" ::
-                     : "cc");
+            : "cc");
 }
 
 void clac()
@@ -43,7 +43,7 @@ void clac()
     if (!Processor::current().has_feature(CPUFeature::SMAP))
         return;
     asm volatile("clac" ::
-                     : "cc");
+            : "cc");
 }
 
 UNMAP_AFTER_INIT void write_cr0(FlatPtr value)
@@ -83,7 +83,7 @@ void write_cr3(FlatPtr cr3)
 {
     // NOTE: If you're here from a GPF crash, it's very likely that a PDPT entry is incorrect, not this!
     asm volatile("mov %%rax, %%cr3" ::"a"(cr3)
-                 : "memory");
+        : "memory");
 }
 
 FlatPtr read_cr4()

--- a/Kernel/Arch/x86_64/ASM_wrapper.h
+++ b/Kernel/Arch/x86_64/ASM_wrapper.h
@@ -16,12 +16,12 @@ namespace Kernel {
 ALWAYS_INLINE void cli()
 {
     asm volatile("cli" ::
-                     : "memory");
+            : "memory");
 }
 ALWAYS_INLINE void sti()
 {
     asm volatile("sti" ::
-                     : "memory");
+            : "memory");
 }
 ALWAYS_INLINE NO_SANITIZE_COVERAGE FlatPtr cpu_flags()
 {
@@ -108,7 +108,7 @@ void write_dr7(FlatPtr);
 ALWAYS_INLINE void read_tsc(u32& lsw, u32& msw)
 {
     asm volatile("rdtsc"
-                 : "=d"(msw), "=a"(lsw));
+        : "=d"(msw), "=a"(lsw));
 }
 
 ALWAYS_INLINE u64 read_tsc()

--- a/Kernel/Arch/x86_64/CPUID.h
+++ b/Kernel/Arch/x86_64/CPUID.h
@@ -21,8 +21,8 @@ public:
     explicit CPUID(u32 function, u32 ecx = 0)
     {
         asm volatile("cpuid"
-                     : "=a"(m_eax), "=b"(m_ebx), "=c"(m_ecx), "=d"(m_edx)
-                     : "a"(function), "c"(ecx));
+            : "=a"(m_eax), "=b"(m_ebx), "=c"(m_ecx), "=d"(m_edx)
+            : "a"(function), "c"(ecx));
     }
 
     u32 eax() const { return m_eax; }

--- a/Kernel/Arch/x86_64/Hypervisor/VMWareBackdoor.cpp
+++ b/Kernel/Arch/x86_64/Hypervisor/VMWareBackdoor.cpp
@@ -38,7 +38,7 @@ inline void vmware_out(VMWareCommand& command)
     command.si = 0;
     command.di = 0;
     asm volatile("in %%dx, %0"
-                 : "+a"(command.ax), "+b"(command.bx), "+c"(command.cx), "+d"(command.dx), "+S"(command.si), "+D"(command.di));
+        : "+a"(command.ax), "+b"(command.bx), "+c"(command.cx), "+d"(command.dx), "+S"(command.si), "+D"(command.di));
 }
 
 inline void vmware_high_bandwidth_send(VMWareCommand& command)
@@ -47,7 +47,7 @@ inline void vmware_high_bandwidth_send(VMWareCommand& command)
     command.port = VMWARE_PORT_HIGHBANDWIDTH;
 
     asm volatile("cld; rep; outsb"
-                 : "+a"(command.ax), "+b"(command.bx), "+c"(command.cx), "+d"(command.dx), "+S"(command.si), "+D"(command.di));
+        : "+a"(command.ax), "+b"(command.bx), "+c"(command.cx), "+d"(command.dx), "+S"(command.si), "+D"(command.di));
 }
 
 inline void vmware_high_bandwidth_get(VMWareCommand& command)
@@ -55,7 +55,7 @@ inline void vmware_high_bandwidth_get(VMWareCommand& command)
     command.magic = VMWARE_MAGIC;
     command.port = VMWARE_PORT_HIGHBANDWIDTH;
     asm volatile("cld; rep; insb"
-                 : "+a"(command.ax), "+b"(command.bx), "+c"(command.cx), "+d"(command.dx), "+S"(command.si), "+D"(command.di));
+        : "+a"(command.ax), "+b"(command.bx), "+c"(command.cx), "+d"(command.dx), "+S"(command.si), "+D"(command.di));
 }
 
 class VMWareBackdoorDetector {

--- a/Kernel/Arch/x86_64/IO.h
+++ b/Kernel/Arch/x86_64/IO.h
@@ -23,8 +23,8 @@ inline u8 in8(u16 port)
 {
     u8 value;
     asm volatile("inb %1, %0"
-                 : "=a"(value)
-                 : "Nd"(port));
+        : "=a"(value)
+        : "Nd"(port));
     return value;
 }
 
@@ -32,8 +32,8 @@ inline u16 in16(u16 port)
 {
     u16 value;
     asm volatile("inw %1, %0"
-                 : "=a"(value)
-                 : "Nd"(port));
+        : "=a"(value)
+        : "Nd"(port));
     return value;
 }
 
@@ -41,8 +41,8 @@ inline u32 in32(u16 port)
 {
     u32 value;
     asm volatile("inl %1, %0"
-                 : "=a"(value)
-                 : "Nd"(port));
+        : "=a"(value)
+        : "Nd"(port));
     return value;
 }
 

--- a/Kernel/Arch/x86_64/MSR.h
+++ b/Kernel/Arch/x86_64/MSR.h
@@ -37,8 +37,8 @@ public:
     {
         u32 low, high;
         asm volatile("rdmsr"
-                     : "=a"(low), "=d"(high)
-                     : "c"(m_msr));
+            : "=a"(low), "=d"(high)
+            : "c"(m_msr));
         return ((u64)high << 32) | low;
     }
 

--- a/Kernel/Arch/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86_64/Processor.cpp
@@ -65,14 +65,14 @@ void ProcessorBase<T>::store_fpu_state(FPUState& fpu_state)
         // The specific state components saved correspond to the bits set in the requested-feature bitmap (RFBM), which is the logical-AND of EDX:EAX and XCR0.
         // https://www.moritz.systems/blog/how-debuggers-work-getting-and-setting-x86-registers-part-2/
         asm volatile("xsave %0\n"
-                     : "=m"(fpu_state)
-                     : "a"(static_cast<u32>(SIMD::StateComponent::AVX | SIMD::StateComponent::SSE | SIMD::StateComponent::X87)), "d"(0u));
+            : "=m"(fpu_state)
+            : "a"(static_cast<u32>(SIMD::StateComponent::AVX | SIMD::StateComponent::SSE | SIMD::StateComponent::X87)), "d"(0u));
     } else if (Processor::current().has_feature(CPUFeature::FXSR)) {
         asm volatile("fxsave %0"
-                     : "=m"(fpu_state));
+            : "=m"(fpu_state));
     } else {
         asm volatile("fnsave %0"
-                     : "=m"(fpu_state));
+            : "=m"(fpu_state));
     }
 }
 
@@ -768,7 +768,7 @@ void Processor::flush_gdt()
     m_gdtr.address = m_gdt;
     m_gdtr.limit = (m_gdt_length * 8) - 1;
     asm volatile("lgdt %0" ::"m"(m_gdtr)
-                 : "memory");
+        : "memory");
 }
 
 DescriptorTablePointer const& Processor::get_gdtr()
@@ -848,9 +848,9 @@ void ProcessorBase<T>::flush_tlb_local(VirtualAddress vaddr, size_t page_count)
     auto ptr = vaddr.as_ptr();
     while (page_count > 0) {
         asm volatile("invlpg %0"
-                     :
-                     : "m"(*ptr)
-                     : "memory");
+            :
+            : "m"(*ptr)
+            : "memory");
         ptr += PAGE_SIZE;
         page_count--;
     }

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
@@ -16,7 +16,7 @@ class NVMeInterruptQueue : public NVMeQueue
 public:
     static ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
-    virtual ~NVMeInterruptQueue() override {};
+    virtual ~NVMeInterruptQueue() override = default;
     virtual StringView purpose() const override { return "NVMe"sv; }
     void initialize_interrupt_queue();
 

--- a/Kernel/Devices/Storage/NVMe/NVMePollQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMePollQueue.h
@@ -14,7 +14,7 @@ class NVMePollQueue : public NVMeQueue {
 public:
     static ErrorOr<NonnullLockRefPtr<NVMePollQueue>> try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
-    virtual ~NVMePollQueue() override {};
+    virtual ~NVMePollQueue() override = default;
 
 protected:
     NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalRAMPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);

--- a/Kernel/EFIPrekernel/Arch/aarch64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/aarch64/Boot.cpp
@@ -38,9 +38,9 @@ namespace Kernel {
 
         br %[kernel_entry]
     )"
-                 :
-                 : "r"(x0), "r"(sp), [sctlr_el1] "r"(sctlr_el1), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
-                 : "memory");
+        :
+        : "r"(x0), "r"(sp), [sctlr_el1] "r"(sctlr_el1), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
+        : "memory");
 
     __builtin_unreachable();
 }
@@ -257,10 +257,10 @@ void arch_prepare_boot(void* root_page_table, BootInfo& boot_info)
         mov x3, %[boot_info_vaddr]
         b enter_kernel_helper
     )" ::[current_el] "r"(current_el),
-                 [sctlr_el2] "r"(sctlr_el2), [hcr_el2] "r"(hcr_el2), [spsr_el2] "r"(spsr_el2),
-                 [sctlr_el1] "r"(sctlr_el1), [root_page_table] "r"(root_page_table), [mair_el1] "r"(mair_el1), [tcr_el1] "r"(tcr_el1),
-                 [sctlr_el1_mmu_on] "r"(sctlr_el1_mmu_on), [kernel_entry_vaddr] "r"(kernel_entry_vaddr), [kernel_stack_pointer] "r"(kernel_stack_pointer), [boot_info_vaddr] "r"(boot_info_vaddr)
-                 : "memory", "cc", "x0", "x1", "x2", "x3");
+        [sctlr_el2] "r"(sctlr_el2), [hcr_el2] "r"(hcr_el2), [spsr_el2] "r"(spsr_el2),
+        [sctlr_el1] "r"(sctlr_el1), [root_page_table] "r"(root_page_table), [mair_el1] "r"(mair_el1), [tcr_el1] "r"(tcr_el1),
+        [sctlr_el1_mmu_on] "r"(sctlr_el1_mmu_on), [kernel_entry_vaddr] "r"(kernel_entry_vaddr), [kernel_stack_pointer] "r"(kernel_stack_pointer), [boot_info_vaddr] "r"(boot_info_vaddr)
+        : "memory", "cc", "x0", "x1", "x2", "x3");
 
     __builtin_unreachable();
 }

--- a/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/riscv64/Boot.cpp
@@ -49,9 +49,9 @@ namespace Kernel {
         wfi
         j 1b
     )"
-                 :
-                 : "r"(a0), "r"(sp), [satp] "r"(satp), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
-                 : "t0", "memory");
+        :
+        : "r"(a0), "r"(sp), [satp] "r"(satp), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
+        : "t0", "memory");
 
     __builtin_unreachable();
 }

--- a/Kernel/EFIPrekernel/Arch/x86_64/Boot.cpp
+++ b/Kernel/EFIPrekernel/Arch/x86_64/Boot.cpp
@@ -76,9 +76,9 @@ namespace Kernel {
         .8byte .Lgdt                  /* base address */
     .previous
     )"
-                 :
-                 : "r"(rdi), [cr3] "r"(cr3), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
-                 : "rax", "memory");
+        :
+        : "r"(rdi), [cr3] "r"(cr3), [kernel_sp] "r"(kernel_sp), [kernel_entry] "r"(kernel_entry)
+        : "rax", "memory");
 
     __builtin_unreachable();
 }

--- a/Kernel/FileSystem/Ext2FS/BlockView.cpp
+++ b/Kernel/FileSystem/Ext2FS/BlockView.cpp
@@ -12,7 +12,9 @@ namespace Kernel {
 static constexpr size_t max_blocks_in_view = 16384; // 2^14
 
 Ext2FSBlockView::Ext2FSBlockView(Ext2FSInode& inode)
-    : m_inode(inode) {};
+    : m_inode(inode)
+{
+}
 
 ErrorOr<void> Ext2FSBlockView::ensure_block(BlockBasedFileSystem::BlockIndex block)
 {

--- a/Kernel/FileSystem/SysFS/Component.h
+++ b/Kernel/FileSystem/SysFS/Component.h
@@ -92,7 +92,7 @@ public:
 protected:
     virtual bool is_root_directory() const { return false; }
 
-    SysFSDirectory() {};
+    SysFSDirectory() = default;
     explicit SysFSDirectory(SysFSDirectory const& parent_directory);
     ChildList m_child_components {};
 };

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h
@@ -18,7 +18,7 @@ public:
     static NonnullRefPtr<PCIDeviceAttributeSysFSComponent> create(PCIDeviceSysFSDirectory const& device, PCI::RegisterOffset offset, size_t field_bytes_width);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
-    virtual ~PCIDeviceAttributeSysFSComponent() {};
+    virtual ~PCIDeviceAttributeSysFSComponent() = default;
 
     virtual StringView name() const override;
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h
@@ -18,7 +18,7 @@ public:
     static NonnullRefPtr<PCIDeviceExpansionROMSysFSComponent> create(PCIDeviceSysFSDirectory const& device);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
-    virtual ~PCIDeviceExpansionROMSysFSComponent() {};
+    virtual ~PCIDeviceExpansionROMSysFSComponent() = default;
 
     virtual StringView name() const override { return "rom"sv; }
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Graphics/DisplayConnector/DeviceAttribute.h
@@ -28,7 +28,7 @@ public:
     static NonnullRefPtr<DisplayConnectorAttributeSysFSComponent> must_create(DisplayConnectorSysFSDirectory const& device_directory, Type);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
-    virtual ~DisplayConnectorAttributeSysFSComponent() {};
+    virtual ~DisplayConnectorAttributeSysFSComponent() = default;
 
     virtual StringView name() const override;
 

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceAttribute.h
@@ -24,7 +24,7 @@ public:
     static NonnullRefPtr<StorageDeviceAttributeSysFSComponent> must_create(StorageDeviceSysFSDirectory const& device_directory, Type);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
-    virtual ~StorageDeviceAttributeSysFSComponent() {};
+    virtual ~StorageDeviceAttributeSysFSComponent() = default;
 
     virtual StringView name() const override;
 

--- a/Kernel/Heap/kmalloc.h
+++ b/Kernel/Heap/kmalloc.h
@@ -40,7 +40,7 @@ struct nothrow_t {
 
 extern nothrow_t const nothrow;
 
-enum class align_val_t : size_t {};
+enum class align_val_t : size_t { };
 };
 
 void kmalloc_init();

--- a/Kernel/Net/IP/SocketTuple.h
+++ b/Kernel/Net/IP/SocketTuple.h
@@ -22,7 +22,9 @@ public:
         : m_local_address(local_address)
         , m_local_port(local_port)
         , m_peer_address(peer_address)
-        , m_peer_port(peer_port) {};
+        , m_peer_port(peer_port)
+    {
+    }
 
     IPv4Address local_address() const { return m_local_address; }
     u16 local_port() const { return m_local_port; }

--- a/Kernel/Net/TCP.h
+++ b/Kernel/Net/TCP.h
@@ -39,7 +39,9 @@ public:
 protected:
     TCPOption(TCPOptionKind kind, u8 length)
         : m_kind(kind)
-        , m_length(length) {};
+        , m_length(length)
+    {
+    }
 
 private:
     TCPOptionKind m_kind { TCPOptionKind::End };

--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -91,7 +91,7 @@ public:
 
 SignalHandlers::SignalHandlers(int signal_number, CFFileDescriptorCallBack handle_signal)
     : m_signal_number(signal_number)
-    , m_original_handler(signal(signal_number, [](int) {}))
+    , m_original_handler(signal(signal_number, [](int) { }))
 {
     m_kevent_fd = kqueue();
     if (m_kevent_fd < 0) {
@@ -319,7 +319,7 @@ static void handle_signal(CFFileDescriptorRef f, CFOptionFlags callback_types, v
     VERIFY(callback_types & kCFFileDescriptorReadCallBack);
     auto* signal_handlers = static_cast<SignalHandlers*>(info);
 
-    struct kevent event { };
+    struct kevent event {};
 
     // returns number of events that have occurred since last call
     (void)::kevent(CFFileDescriptorGetNativeDescriptor(f), nullptr, 0, &event, 1, nullptr);

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -201,7 +201,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 
     self.tab.titlebarAppearsTransparent = NO;
 
-    [delegate createNewTab:OptionalNone {}
+    [delegate createNewTab:OptionalNone { }
                    fromTab:[self tab]
                activateTab:Web::HTML::ActivateTab::Yes];
 

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -194,7 +194,7 @@
 - (void)pageChanged
 {
     [self.window setSubtitle:
-                     [NSString stringWithFormat:@"Page %d of %d", [_pdfView page], _pdfDocument.pdf->get_page_count()]];
+            [NSString stringWithFormat:@"Page %d of %d", [_pdfView page], _pdfDocument.pdf->get_page_count()]];
 }
 
 #pragma mark - NSToolbarDelegate

--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -38,7 +38,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
         switch (header.type_flag()) {
         case Archive::TarFileType::GlobalExtendedHeader:
         case Archive::TarFileType::ExtendedHeader: {
-            auto result = tar_stream->for_each_extended_header([&](StringView, StringView) {});
+            auto result = tar_stream->for_each_extended_header([&](StringView, StringView) { });
             if (result.is_error())
                 return 0;
             break;

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -30,21 +30,21 @@ fi
 if (( ${#files[@]} )); then
     TOOLCHAIN_DIR=Toolchain/Local/clang/bin
     CLANG_FORMAT=false
-    if command -v clang-format-18 >/dev/null 2>&1 ; then
-        CLANG_FORMAT=clang-format-18
-    elif command -v brew >/dev/null 2>&1 && command -v "$(brew --prefix llvm@18)"/bin/clang-format >/dev/null 2>&1 ; then
-        CLANG_FORMAT="$(brew --prefix llvm@18)"/bin/clang-format
-    elif command -v $TOOLCHAIN_DIR/clang-format >/dev/null 2>&1 && $TOOLCHAIN_DIR/clang-format --version | grep -qF ' 18.' ; then
+    if command -v clang-format-20 >/dev/null 2>&1 ; then
+        CLANG_FORMAT=clang-format-20
+    elif command -v brew >/dev/null 2>&1 && command -v "$(brew --prefix llvm@20)"/bin/clang-format >/dev/null 2>&1 ; then
+        CLANG_FORMAT="$(brew --prefix llvm@20)"/bin/clang-format
+    elif command -v $TOOLCHAIN_DIR/clang-format >/dev/null 2>&1 && $TOOLCHAIN_DIR/clang-format --version | grep -qF ' 20.' ; then
         CLANG_FORMAT=$TOOLCHAIN_DIR/clang-format
     elif command -v clang-format >/dev/null 2>&1 ; then
         CLANG_FORMAT=clang-format
-        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) < 18) exit 1; }'; then
-            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 18 or later."
+        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) < 20) exit 1; }'; then
+            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format-20 or later."
             echo "It is very likely that the resulting changes are not what you wanted."
         fi
     else
-        echo "clang-format-18 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-18."
-        echo "(If you install a package 'clang-format', please make sure it's version 18 or later.)"
+        echo "clang-format-20 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-20."
+        echo "(If you install a package 'clang-format', please make sure it's version 20 or later.)"
         exit 1
     fi
 

--- a/Tests/Kernel/TestSigHandler.cpp
+++ b/Tests/Kernel/TestSigHandler.cpp
@@ -18,7 +18,7 @@ static void signal_handler(int)
 
 TEST_CASE(default_handlers)
 {
-    struct sigaction current_action { };
+    struct sigaction current_action {};
 
     int rc = sigaction(SIGUSR2, nullptr, &current_action);
 
@@ -37,7 +37,7 @@ TEST_CASE(handlers_after_fork)
     pid_t pid = fork();
 
     if (pid == 0) {
-        struct sigaction current_action { };
+        struct sigaction current_action {};
         rc = sigaction(SIGUSR2, nullptr, &current_action);
         EXPECT_EQ(rc, 0);
         EXPECT_EQ(current_action.sa_handler, signal_handler);

--- a/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
+++ b/Userland/Applications/CertificateSettings/CertificateStoreWidget.h
@@ -25,7 +25,9 @@ public:
 private:
     CertificateStoreProxyModel(NonnullRefPtr<Model> source, NonnullRefPtr<GUI::TableView> view)
         : SortingProxyModel(move(source))
-        , m_parent_table_view(move(view)) {};
+        , m_parent_table_view(move(view))
+    {
+    }
 
     NonnullRefPtr<GUI::TableView> m_parent_table_view;
 };
@@ -60,7 +62,7 @@ public:
     virtual ~CertificateStoreWidget() override = default;
     static ErrorOr<NonnullRefPtr<CertificateStoreWidget>> try_create();
     ErrorOr<void> initialize();
-    virtual void apply_settings() override {};
+    virtual void apply_settings() override { }
 
 private:
     CertificateStoreWidget() = default;

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -245,8 +245,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     g_debug_session = create_debug_session(command, pid_to_debug);
 
-    struct sigaction sa {
-    };
+    struct sigaction sa {};
     sa.sa_handler = handle_sigint;
     TRY(Core::System::sigaction(SIGINT, &sa, nullptr));
 

--- a/Userland/Applications/Help/ManualModel.h
+++ b/Userland/Applications/Help/ManualModel.h
@@ -19,7 +19,7 @@ public:
         return adopt_nonnull_ref_or_enomem(new (nothrow) ManualModel);
     }
 
-    virtual ~ManualModel() override {};
+    virtual ~ManualModel() override = default;
 
     Optional<GUI::ModelIndex> index_from_path(StringView) const;
 

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -115,7 +115,7 @@ private:
 
 class KeymapModel final : public GUI::Model {
 public:
-    KeymapModel() {};
+    KeymapModel() = default;
 
     int row_count(GUI::ModelIndex const&) const override { return m_data.size(); }
     int column_count(GUI::ModelIndex const&) const override { return 1; }

--- a/Userland/Applications/PixelPaint/Filters/Bloom.h
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.h
@@ -19,7 +19,9 @@ public:
     virtual StringView filter_name() const override { return "Bloom Filter"sv; }
 
     Bloom(ImageEditor* editor)
-        : InplaceFilter(editor) {};
+        : InplaceFilter(editor)
+    {
+    }
 
 private:
     int m_luma_lower { 128 };

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur3.h
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur3.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Box Blur (3x3)"sv; }
 
     BoxBlur3(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur5.h
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur5.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Box Blur (5x5)"sv; }
 
     BoxBlur5(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
@@ -20,7 +20,9 @@ public:
     virtual StringView filter_name() const override { return "Fast Box Blur (& Gauss)"sv; }
 
     FastBoxBlur(ImageEditor* editor)
-        : InplaceFilter(editor) {};
+        : InplaceFilter(editor)
+    {
+    }
 
 private:
     size_t m_radius { 5 };

--- a/Userland/Applications/PixelPaint/Filters/Filter.h
+++ b/Userland/Applications/PixelPaint/Filters/Filter.h
@@ -26,7 +26,7 @@ public:
 
     virtual StringView filter_name() const = 0;
 
-    virtual ~Filter() {};
+    virtual ~Filter() = default;
 
     Filter(ImageEditor* editor);
 

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur3.h
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur3.h
@@ -17,7 +17,9 @@ public:
     virtual StringView filter_name() const override { return "Gaussian Blur (3x3)"sv; }
 
     GaussBlur3(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur5.h
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur5.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Gaussian Blur (5x5)"sv; }
 
     GaussBlur5(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Grayscale.h
+++ b/Userland/Applications/PixelPaint/Filters/Grayscale.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Grayscale"sv; }
 
     Grayscale(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/HueAndSaturation.h
+++ b/Userland/Applications/PixelPaint/Filters/HueAndSaturation.h
@@ -18,7 +18,9 @@ public:
     virtual StringView filter_name() const override { return "Hue/Saturation"sv; }
 
     HueAndSaturation(ImageEditor* editor)
-        : InplaceFilter(editor) {};
+        : InplaceFilter(editor)
+    {
+    }
 
 private:
     float m_hue { 0 };

--- a/Userland/Applications/PixelPaint/Filters/Invert.h
+++ b/Userland/Applications/PixelPaint/Filters/Invert.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Invert"sv; }
 
     Invert(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.h
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Laplacian Cardinal"sv; }
 
     LaplaceCardinal(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.h
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Laplacian Diagonal"sv; }
 
     LaplaceDiagonal(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Sepia.h
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.h
@@ -18,7 +18,9 @@ public:
     virtual StringView filter_name() const override { return "Sepia"sv; }
 
     Sepia(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 
 private:
     float m_amount { 1.0f };

--- a/Userland/Applications/PixelPaint/Filters/Sharpen.h
+++ b/Userland/Applications/PixelPaint/Filters/Sharpen.h
@@ -16,7 +16,9 @@ public:
     virtual StringView filter_name() const override { return "Sharpen"sv; }
 
     Sharpen(ImageEditor* editor)
-        : Filter(editor) {};
+        : Filter(editor)
+    {
+    }
 };
 
 }

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -37,7 +37,7 @@ class MainWidget : public GUI::Widget {
     C_OBJECT(MainWidget);
 
 public:
-    virtual ~MainWidget() {};
+    virtual ~MainWidget() = default;
 
     ErrorOr<void> initialize_menubar(GUI::Window&);
 

--- a/Userland/Applications/SpaceAnalyzer/Tree.cpp
+++ b/Userland/Applications/SpaceAnalyzer/Tree.cpp
@@ -42,7 +42,9 @@ void TreeNode::sort_children_by_area() const
 struct QueueEntry {
     QueueEntry(ByteString path, TreeNode* node)
         : path(move(path))
-        , node(node) {};
+        , node(node)
+    {
+    }
     ByteString path;
     TreeNode* node { nullptr };
 };

--- a/Userland/Applications/SpaceAnalyzer/Tree.h
+++ b/Userland/Applications/SpaceAnalyzer/Tree.h
@@ -49,7 +49,7 @@ public:
     {
         return adopt_nonnull_own_or_enomem(new (nothrow) Tree(move(root_name)));
     }
-    ~Tree() {};
+    ~Tree() = default;
 
     TreeNode& root()
     {

--- a/Userland/Applications/SpaceAnalyzer/Tree.h
+++ b/Userland/Applications/SpaceAnalyzer/Tree.h
@@ -19,7 +19,9 @@ struct MountInfo {
 class TreeNode final {
 public:
     TreeNode(ByteString name)
-        : m_name(move(name)) {};
+        : m_name(move(name))
+    {
+    }
 
     ByteString name() const { return m_name; }
     i64 area() const { return m_area; }
@@ -58,6 +60,8 @@ public:
 
 private:
     Tree(ByteString root_name)
-        : m_root(move(root_name)) {};
+        : m_root(move(root_name))
+    {
+    }
     TreeNode m_root;
 };

--- a/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
+++ b/Userland/Applications/VideoPlayer/VideoPlayerWidget.cpp
@@ -393,7 +393,7 @@ ErrorOr<void> VideoPlayerWidget::initialize_menubar(GUI::Window& window)
 
     // FIXME: Maybe seek mode should be in an options dialog instead. The playback menu may get crowded.
     //        For now, leave it here for convenience.
-    m_use_fast_seeking = GUI::Action::create_checkable("&Fast Seeking", [&](auto&) {});
+    m_use_fast_seeking = GUI::Action::create_checkable("&Fast Seeking", [&](auto&) { });
     playback_menu->add_action(*m_use_fast_seeking);
     set_seek_mode(Media::PlaybackManager::DEFAULT_SEEK_MODE);
 

--- a/Userland/DevTools/HackStudio/ClassViewWidget.h
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.h
@@ -36,7 +36,9 @@ struct ClassViewNode {
     ClassViewNode* parent { nullptr };
 
     explicit ClassViewNode(StringView name)
-        : name(name) {};
+        : name(name)
+    {
+    }
 };
 
 class ClassViewModel final : public GUI::Model {

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -88,13 +88,13 @@ ErrorOr<NonnullRefPtr<GUI::TextDocument>> FileDB::create_from_fd(int fd) const
 class DefaultDocumentClient final : public GUI::TextDocument::Client {
 public:
     virtual ~DefaultDocumentClient() override = default;
-    virtual void document_did_append_line() override {};
-    virtual void document_did_insert_line(size_t) override {};
-    virtual void document_did_remove_line(size_t) override {};
-    virtual void document_did_remove_all_lines() override {};
+    virtual void document_did_append_line() override { }
+    virtual void document_did_insert_line(size_t) override { }
+    virtual void document_did_remove_line(size_t) override { }
+    virtual void document_did_remove_all_lines() override { }
     virtual void document_did_change(GUI::AllowCallback) override {};
     virtual void document_did_set_text(GUI::AllowCallback) override {};
-    virtual void document_did_set_cursor(const GUI::TextPosition&) override {};
+    virtual void document_did_set_cursor(const GUI::TextPosition&) override { }
     virtual void document_did_update_undo_stack() override { }
 
     virtual bool is_automatic_indentation_enabled() const override { return false; }

--- a/Userland/DevTools/Profiler/FilesystemEventModel.h
+++ b/Userland/DevTools/Profiler/FilesystemEventModel.h
@@ -53,7 +53,9 @@ public:
 private:
     FileEventNode(ByteString const& path, FileEventNode* parent = nullptr)
         : m_path(path)
-        , m_parent(parent) {};
+        , m_parent(parent)
+    {
+    }
 
     ByteString m_path;
 

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -22,7 +22,7 @@ public:
     virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override { return true; }
-    virtual void close() override {};
+    virtual void close() override { }
 
 private:
     TarFileStream(TarInputStream& stream);

--- a/Userland/Libraries/LibAudio/ConnectionToServer.cpp
+++ b/Userland/Libraries/LibAudio/ConnectionToServer.cpp
@@ -35,7 +35,7 @@ ConnectionToServer::ConnectionToServer(NonnullOwnPtr<Core::LocalSocket> socket)
             Threading::MutexLocker const locker(m_enqueuer_loop_destruction);
             m_enqueuer_loop = nullptr;
         }
-        return (intptr_t) nullptr;
+        return (intptr_t)nullptr;
     }))
 {
     update_good_sleep_time();

--- a/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/riscv64/fenv.cpp
@@ -74,7 +74,7 @@ static RoundingMode get_rounding_mode()
 {
     size_t rounding_mode;
     asm volatile("frrm %0"
-                 : "=r"(rounding_mode));
+        : "=r"(rounding_mode));
     return static_cast<RoundingMode>(rounding_mode);
 }
 
@@ -84,8 +84,8 @@ static RoundingMode set_rounding_mode(RoundingMode frm)
     size_t old_rounding_mode;
     size_t const new_rounding_mode = to_underlying(frm);
     asm volatile("fsrm %0, %1"
-                 : "=r"(old_rounding_mode)
-                 : "r"(new_rounding_mode));
+        : "=r"(old_rounding_mode)
+        : "r"(new_rounding_mode));
     return static_cast<RoundingMode>(old_rounding_mode);
 }
 
@@ -145,7 +145,7 @@ static AccruedExceptions get_accrued_exceptions()
 {
     size_t fflags;
     asm volatile("frflags %0"
-                 : "=r"(fflags));
+        : "=r"(fflags));
     return static_cast<AccruedExceptions>(fflags);
 }
 
@@ -155,8 +155,8 @@ static AccruedExceptions set_accrued_exceptions(AccruedExceptions exceptions)
     size_t old_exceptions;
     size_t const new_exceptions = to_underlying(exceptions);
     asm volatile("fsflags %0, %1"
-                 : "=r"(old_exceptions)
-                 : "r"(new_exceptions));
+        : "=r"(old_exceptions)
+        : "r"(new_exceptions));
     return static_cast<AccruedExceptions>(old_exceptions);
 }
 
@@ -174,7 +174,7 @@ int fegetenv(fenv_t* env)
 
     FlatPtr fcsr;
     asm volatile("csrr %0, fcsr"
-                 : "=r"(fcsr));
+        : "=r"(fcsr));
     env->fcsr = fcsr;
 
     return 0;

--- a/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
+++ b/Userland/Libraries/LibC/arch/x86_64/fenv.cpp
@@ -14,7 +14,7 @@ static u16 read_status_register()
 {
     u16 status_register;
     asm volatile("fnstsw %0"
-                 : "=m"(status_register));
+        : "=m"(status_register));
     return status_register;
 }
 
@@ -22,7 +22,7 @@ static u16 read_control_word()
 {
     u16 control_word;
     asm volatile("fnstcw %0"
-                 : "=m"(control_word));
+        : "=m"(control_word));
     return control_word;
 }
 
@@ -35,7 +35,7 @@ static u32 read_mxcsr()
 {
     u32 mxcsr;
     asm volatile("stmxcsr %0"
-                 : "=m"(mxcsr));
+        : "=m"(mxcsr));
     return mxcsr;
 }
 
@@ -54,7 +54,7 @@ int fegetenv(fenv_t* env)
         return 1;
 
     asm volatile("fnstenv %0"
-                 : "=m"(env->__x87_fpu_env)::"memory");
+        : "=m"(env->__x87_fpu_env)::"memory");
 
     env->__mxcsr = read_mxcsr();
     return 0;
@@ -72,7 +72,7 @@ int fesetenv(fenv_t const* env)
     }
 
     asm volatile("fldenv %0" ::"m"(env->__x87_fpu_env)
-                 : "memory");
+        : "memory");
 
     set_mxcsr(env->__mxcsr);
     return 0;

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -1068,7 +1068,7 @@ char* getpass(char const* prompt)
             close(tty);
         });
 
-        struct termios backup { };
+        struct termios backup {};
         if (tcgetattr(tty, &backup) < 0)
             return nullptr;
 

--- a/Userland/Libraries/LibCodeComprehension/CodeComprehensionEngine.h
+++ b/Userland/Libraries/LibCodeComprehension/CodeComprehensionEngine.h
@@ -27,8 +27,8 @@ public:
     virtual Vector<AutocompleteResultEntry> get_suggestions(ByteString const& file, GUI::TextPosition const& autocomplete_position) = 0;
 
     // TODO: In the future we can pass the range that was edited and only re-parse what we have to.
-    virtual void on_edit([[maybe_unused]] ByteString const& file) {};
-    virtual void file_opened([[maybe_unused]] ByteString const& file) {};
+    virtual void on_edit([[maybe_unused]] ByteString const& file) { }
+    virtual void file_opened([[maybe_unused]] ByteString const& file) { }
 
     virtual Optional<ProjectLocation> find_declaration_of(ByteString const&, GUI::TextPosition const&) { return {}; }
 

--- a/Userland/Libraries/LibCompress/Brotli.h
+++ b/Userland/Libraries/LibCompress/Brotli.h
@@ -20,7 +20,9 @@ public:
     CanonicalCode() = default;
     CanonicalCode(Vector<size_t> codes, Vector<size_t> values)
         : m_symbol_codes(move(codes))
-        , m_symbol_values(move(values)) {};
+        , m_symbol_values(move(values))
+    {
+    }
 
     static ErrorOr<CanonicalCode> read_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size);
     static ErrorOr<CanonicalCode> read_simple_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size);

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -49,7 +49,7 @@ public:
     virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual bool is_eof() const override;
     virtual bool is_open() const override { return true; }
-    virtual void close() override {};
+    virtual void close() override { }
 
     static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
 

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -73,7 +73,7 @@ ErrorOr<void> Command::write_lines(Span<ByteString> lines)
     // It's possible the process dies before we can write everything to the
     // stdin. So make sure that we don't crash but just stop writing.
 
-    struct sigaction action_handler { };
+    struct sigaction action_handler {};
     action_handler.sa_handler = SIG_IGN;
 
     struct sigaction old_action_handler;

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -284,7 +284,7 @@ ErrorOr<bool> Process::is_being_debugged()
     if (sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0) < 0)
         return Error::from_syscall("sysctl"sv, -errno);
 
-        // We're being debugged if the P_TRACED flag is set.
+    // We're being debugged if the P_TRACED flag is set.
 #    if defined(AK_OS_MACOS)
     return ((info.kp_proc.p_flag & P_TRACED) != 0);
 #    elif defined(AK_OS_FREEBSD)

--- a/Userland/Libraries/LibCore/ThreadedPromise.h
+++ b/Userland/Libraries/LibCore/ThreadedPromise.h
@@ -112,7 +112,7 @@ public:
     // Set the callback to be called when the promise is rejected. Setting this callback
     // will cause the promise fulfillment to be ready to be handled.
     template<CallableAs<void, ErrorType&&> RejectedHandler>
-    ThreadedPromise& when_rejected(RejectedHandler when_rejected = [](ErrorType&) {})
+    ThreadedPromise& when_rejected(RejectedHandler when_rejected = [](ErrorType&) { })
     {
         Threading::MutexLocker locker { m_mutex };
         VERIFY(!m_rejection_handler);

--- a/Userland/Libraries/LibCoredump/Inspector.cpp
+++ b/Userland/Libraries/LibCoredump/Inspector.cpp
@@ -68,7 +68,7 @@ PtraceRegisters Inspector::get_registers() const
     return registers;
 }
 
-void Inspector::set_registers(PtraceRegisters const&) {};
+void Inspector::set_registers(PtraceRegisters const&) { }
 
 void Inspector::for_each_loaded_library(Function<IterationDecision(Debug::LoadedLibrary const&)> func) const
 {

--- a/Userland/Libraries/LibCrypto/BigFraction/BigFraction.cpp
+++ b/Userland/Libraries/LibCrypto/BigFraction/BigFraction.cpp
@@ -194,8 +194,8 @@ ByteString BigFraction::to_byte_string(unsigned rounding_threshold) const
     auto const number_of_digits = [](auto integer) {
         unsigned size = 1;
         for (auto division_result = integer.divided_by(UnsignedBigInteger { 10 });
-             division_result.remainder == UnsignedBigInteger { 0 } && division_result.quotient != UnsignedBigInteger { 0 };
-             division_result = division_result.quotient.divided_by(UnsignedBigInteger { 10 })) {
+            division_result.remainder == UnsignedBigInteger { 0 } && division_result.quotient != UnsignedBigInteger { 0 };
+            division_result = division_result.quotient.divided_by(UnsignedBigInteger { 10 })) {
             ++size;
         }
         return size;

--- a/Userland/Libraries/LibCrypto/Cipher/AES.h
+++ b/Userland/Libraries/LibCrypto/Cipher/AES.h
@@ -99,8 +99,8 @@ private:
     template<CPUFeatures>
     void expand_decrypt_key_impl(ReadonlyBytes user_key, size_t bits);
 
-    static void (AESCipherKey::*const expand_encrypt_key_dispatched)(ReadonlyBytes user_key, size_t bits);
-    static void (AESCipherKey::*const expand_decrypt_key_dispatched)(ReadonlyBytes user_key, size_t bits);
+    static void (AESCipherKey::* const expand_encrypt_key_dispatched)(ReadonlyBytes user_key, size_t bits);
+    static void (AESCipherKey::* const expand_decrypt_key_dispatched)(ReadonlyBytes user_key, size_t bits);
 
     static constexpr size_t MAX_ROUND_COUNT = 14;
     u32 m_rd_keys[(MAX_ROUND_COUNT + 1) * 4] { 0 };
@@ -144,8 +144,8 @@ private:
     template<CPUFeatures>
     void decrypt_block_impl(BlockType const& in, BlockType& out);
 
-    static void (AESCipher::*const encrypt_block_dispatched)(BlockType const& in, BlockType& out);
-    static void (AESCipher::*const decrypt_block_dispatched)(BlockType const& in, BlockType& out);
+    static void (AESCipher::* const encrypt_block_dispatched)(BlockType const& in, BlockType& out);
+    static void (AESCipher::* const decrypt_block_dispatched)(BlockType const& in, BlockType& out);
 };
 
 }

--- a/Userland/Libraries/LibCrypto/Hash/SHA1.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA1.h
@@ -71,7 +71,7 @@ private:
     template<CPUFeatures>
     void transform_impl();
 
-    static void (SHA1::*const transform_dispatched)();
+    static void (SHA1::* const transform_dispatched)();
     void transform() { return (this->*transform_dispatched)(); }
 
     u8 m_data_buffer[BlockSize] {};

--- a/Userland/Libraries/LibCrypto/Hash/SHA2.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA2.h
@@ -119,7 +119,7 @@ private:
     template<CPUFeatures>
     void transform_impl();
 
-    static void (SHA256::*const transform_dispatched)();
+    static void (SHA256::* const transform_dispatched)();
     void transform() { return (this->*transform_dispatched)(); }
 
     u8 m_data_buffer[BlockSize] {};

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -428,7 +428,7 @@ bool can_delete_or_move(StringView path)
     auto stat_or_empty = [](StringView path) {
         auto stat_or_error = Core::System::stat(path);
         if (stat_or_error.is_error()) {
-            struct stat stat { };
+            struct stat stat {};
             return stat;
         }
         return stat_or_error.release_value();

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -85,7 +85,7 @@ protected:
     virtual void resize_event(ResizeEvent&) override;
     virtual void mousewheel_event(MouseEvent&) override;
     virtual void did_scroll() { }
-    virtual void automatic_scrolling_timer_did_fire() {};
+    virtual void automatic_scrolling_timer_did_fire() { }
     void set_content_size(Gfx::IntSize);
     void set_min_content_size(Gfx::IntSize);
     void set_size_occupied_by_fixed_elements(Gfx::IntSize);

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -50,7 +50,7 @@ protected:
         return *m_inactive_window_icon;
     }
 
-    virtual void palette_changed() {};
+    virtual void palette_changed() { }
 
 private:
     virtual void paint_preview(GUI::PaintEvent&) = 0;

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -91,7 +91,7 @@ class DialogButton final : public Button {
     C_OBJECT(DialogButton);
 
 public:
-    virtual ~DialogButton() override {};
+    virtual ~DialogButton() override = default;
     explicit DialogButton(String text = {})
         : Button(move(text))
     {

--- a/Userland/Libraries/LibGUI/DynamicWidgetContainer.h
+++ b/Userland/Libraries/LibGUI/DynamicWidgetContainer.h
@@ -50,7 +50,7 @@ public:
 
 protected:
     explicit DynamicWidgetContainer(Gfx::Orientation = Gfx::Orientation::Vertical);
-    virtual void paint_event(PaintEvent&) override {};
+    virtual void paint_event(PaintEvent&) override { }
     virtual void second_paint_event(PaintEvent&) override;
     virtual void resize_event(ResizeEvent&) override;
     virtual void child_event(Core::ChildEvent&) override;

--- a/Userland/Libraries/LibGfx/BitmapMixer.h
+++ b/Userland/Libraries/LibGfx/BitmapMixer.h
@@ -18,7 +18,9 @@ public:
     };
 
     BitmapMixer(Bitmap& bitmap)
-        : m_bitmap(bitmap) {};
+        : m_bitmap(bitmap)
+    {
+    }
 
     void mix_with(Bitmap&, MixingMethod);
 

--- a/Userland/Libraries/LibGfx/Filters/Filter.h
+++ b/Userland/Libraries/LibGfx/Filters/Filter.h
@@ -24,8 +24,8 @@ public:
 
     virtual StringView class_name() const = 0;
 
-    virtual void apply(Bitmap&, IntRect const&, Bitmap const&, IntRect const&, Parameters const&) {};
-    virtual void apply(Bitmap&, IntRect const&, Bitmap const&, IntRect const&) {};
+    virtual void apply(Bitmap&, IntRect const&, Bitmap const&, IntRect const&, Parameters const&) { }
+    virtual void apply(Bitmap&, IntRect const&, Bitmap const&, IntRect const&) { }
 
 protected:
     Filter() = default;

--- a/Userland/Libraries/LibGfx/Filters/LumaFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/LumaFilter.h
@@ -13,7 +13,9 @@ namespace Gfx {
 class LumaFilter {
 public:
     LumaFilter(Bitmap& bitmap)
-        : m_bitmap(bitmap) {};
+        : m_bitmap(bitmap)
+    {
+    }
 
     void apply(u8 lower_bound, u8 upper_bound);
 

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -154,7 +154,7 @@ public:
 
     virtual NonnullRefPtr<Font> clone() const = 0;
     virtual ErrorOr<NonnullRefPtr<Font>> try_clone() const = 0;
-    virtual ~Font() {};
+    virtual ~Font() = default;
 
     virtual FontPixelMetrics pixel_metrics() const = 0;
 

--- a/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ISOBMFF/Reader.cpp
@@ -48,7 +48,7 @@ ErrorOr<BoxList> Reader::read_entire_file()
             return OptionalNone {};
         }
     };
-    return read_entire_file((ErrorOr<Optional<NonnullOwnPtr<Box>>>(*)(BoxType, ConstrainedStream&))(make_top_level_box));
+    return read_entire_file((ErrorOr<Optional<NonnullOwnPtr<Box>>> (*)(BoxType, ConstrainedStream&))(make_top_level_box));
 }
 
 ErrorOr<BoxList> Reader::read_entire_file(BoxCallback box_factory)

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -48,7 +48,7 @@ public:
     }
 
 protected:
-    virtual void fill_main_tags() const {};
+    virtual void fill_main_tags() const { }
 
     mutable HashMap<StringView, String> m_main_tags;
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -41,7 +41,7 @@ private:
 ALWAYS_INLINE ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& bit_stream, u32 symbol) const
 {
     TRY(m_code.visit(
-        [&](u32 single_code) __attribute__((always_inline))->ErrorOr<void> { VERIFY(symbol == single_code); return {}; },
+        [&](u32 single_code) __attribute__((always_inline)) -> ErrorOr<void> { VERIFY(symbol == single_code); return {}; },
         [&](Compress::CanonicalCode const& code) __attribute__((always_inline)) { return code.write_symbol(bit_stream, symbol); }));
     return {};
 }

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -67,7 +67,9 @@ public:
 
     PathSegment(Command command, ReadonlySpan<FloatPoint> points)
         : m_command(command)
-        , m_points(points) {};
+        , m_points(points)
+    {
+    }
 
 private:
     Command m_command;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -720,7 +720,7 @@ public:
     virtual bool has_name() const = 0;
     virtual Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString given_name) const = 0;
 
-    virtual ~FunctionNode() {};
+    virtual ~FunctionNode() = default;
 
 protected:
     FunctionNode(RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights parsing_insights, bool is_arrow_function, Vector<DeprecatedFlyString> local_variables_names)
@@ -780,7 +780,7 @@ public:
     bool has_name() const override { return true; }
     Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString) const override { VERIFY_NOT_REACHED(); }
 
-    virtual ~FunctionDeclaration() {};
+    virtual ~FunctionDeclaration() = default;
 
 private:
     bool m_is_hoisted { false };
@@ -807,7 +807,7 @@ public:
 
     Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString given_name) const override;
 
-    virtual ~FunctionExpression() {};
+    virtual ~FunctionExpression() = default;
 
 private:
     virtual bool is_function_expression() const override { return true; }

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -101,7 +101,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ErrorConstructor::construct(FunctionObje
         auto message = vm.argument(0);                                                                                      \
         auto options = vm.argument(1);                                                                                      \
                                                                                                                             \
-        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */       \
+        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */         \
         auto error = TRY(ordinary_create_from_constructor<ClassName>(vm, new_target, &Intrinsics::snake_name##_prototype)); \
                                                                                                                             \
         /* 3. If message is not undefined, then */                                                                          \

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -48,7 +48,9 @@ public:
 
 protected:
     explicit IndexedPropertyStorage(IsSimpleStorage is_simple_storage)
-        : m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes) {};
+        : m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes)
+    {
+    }
 
 private:
     bool m_is_simple_storage { false };
@@ -57,7 +59,9 @@ private:
 class SimpleIndexedPropertyStorage final : public IndexedPropertyStorage {
 public:
     SimpleIndexedPropertyStorage()
-        : IndexedPropertyStorage(IsSimpleStorage::Yes) {};
+        : IndexedPropertyStorage(IsSimpleStorage::Yes)
+    {
+    }
     explicit SimpleIndexedPropertyStorage(Vector<Value>&& initial_values);
 
     virtual bool has_index(u32 index) const override;
@@ -99,7 +103,9 @@ class GenericIndexedPropertyStorage final : public IndexedPropertyStorage {
 public:
     explicit GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&&);
     explicit GenericIndexedPropertyStorage()
-        : IndexedPropertyStorage(IsSimpleStorage::No) {};
+        : IndexedPropertyStorage(IsSimpleStorage::No)
+    {
+    }
 
     virtual bool has_index(u32 index) const override;
     virtual Optional<ValueAndAttributes> get(u32 index) const override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -189,7 +189,7 @@ private:
 };
 
 struct DurationInstanceComponent {
-    double Temporal::DurationRecord::*value_slot;
+    double Temporal::DurationRecord::* value_slot;
     DurationFormat::ValueStyle (DurationFormat::*get_style_slot)() const;
     void (DurationFormat::*set_style_slot)(StringView);
     DurationFormat::Display (DurationFormat::*get_display_slot)() const;

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -44,7 +44,7 @@ private:
         auto&& _temporary_try_or_reject_result = (expression);                                                                           \
         /* 1. If value is an abrupt completion, then */                                                                                  \
         if (_temporary_try_or_reject_result.is_error()) {                                                                                \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                            \
+            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                              \
             CALL_CHECK(JS::call(vm, *(capability)->reject(), js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
                                                                                                                                          \
             /* b. Return capability.[[Promise]]. */                                                                                      \
@@ -70,7 +70,7 @@ private:
         auto&& _temporary_try_or_reject_result = (expression);                                                                    \
         /* 1. If value is an abrupt completion, then */                                                                           \
         if (_temporary_try_or_reject_result.is_error()) {                                                                         \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                     \
+            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                       \
             TRY(JS::call(vm, *(capability)->reject(), js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
                                                                                                                                   \
             /* b. Return capability.[[Promise]]. */                                                                               \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -116,7 +116,7 @@ struct RoundedDuration {
 
 template<typename StructT, typename ValueT>
 struct TemporalDurationRecordField {
-    ValueT StructT::*field_name { nullptr };
+    ValueT StructT::* field_name { nullptr };
     PropertyKey property_name;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
@@ -69,7 +69,7 @@ struct TemporalTimeLikeRecord {
 
 template<typename StructT, typename ValueT>
 struct TemporalTimeLikeRecordField {
-    ValueT StructT::*field_name { nullptr };
+    ValueT StructT::* field_name { nullptr };
     PropertyKey property_name;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -2386,8 +2386,8 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
         // b. Let ly be the length of py.
         // c. For each integer i such that 0 ≤ i < min(lx, ly), in ascending order, do
         for (auto k = x_code_points.begin(), l = y_code_points.begin();
-             k != x_code_points.end() && l != y_code_points.end();
-             ++k, ++l) {
+            k != x_code_points.end() && l != y_code_points.end();
+            ++k, ++l) {
             // i. Let cx be the integer that is the numeric value of the code unit at index i within px.
             // ii. Let cy be the integer that is the numeric value of the code unit at index i within py.
             if (*k != *l) {

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -176,7 +176,7 @@ Result<NonnullGCPtr<SourceTextModule>, Vector<ParserError>> SourceTextModule::pa
                                      [&](ImportEntry const& import_entry) {
                                          return import_entry.local_name == entry.local_or_import_name;
                                      })
-                       .is_end());
+                    .is_end());
             default_export = export_statement;
         }
 

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -468,10 +468,8 @@ private:
 
     KeyCallbackMachine m_callback_machine;
 
-    struct termios m_termios {
-    };
-    struct termios m_default_termios {
-    };
+    struct termios m_termios {};
+    struct termios m_default_termios {};
     bool m_was_interrupted { false };
     bool m_previous_interrupt_was_handled_as_interrupt { true };
     bool m_was_resized { false };

--- a/Userland/Libraries/LibLine/KeyCallbackMachine.h
+++ b/Userland/Libraries/LibLine/KeyCallbackMachine.h
@@ -25,7 +25,9 @@ struct Key {
 
     Key(unsigned c)
         : modifiers(None)
-        , key(c) {};
+        , key(c)
+    {
+    }
 
     Key(unsigned c, int modifiers)
         : modifiers(modifiers)

--- a/Userland/Libraries/LibMedia/VideoDecoder.h
+++ b/Userland/Libraries/LibMedia/VideoDecoder.h
@@ -16,7 +16,7 @@ namespace Media {
 
 class VideoDecoder {
 public:
-    virtual ~VideoDecoder() {};
+    virtual ~VideoDecoder() = default;
 
     virtual DecoderErrorOr<void> receive_sample(Duration timestamp, ReadonlyBytes sample) = 0;
     DecoderErrorOr<void> receive_sample(Duration timestamp, ByteBuffer const& sample) { return receive_sample(timestamp, sample.span()); }

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -704,7 +704,7 @@ PDFErrorOr<Vector<DocumentParser::PageOffsetHintTableEntry>> DocumentParser::par
     auto bits_required_for_greatest_shared_obj_identifier = hint_table.bits_required_for_greatest_shared_obj_identifier;
     auto bits_required_for_fraction_numerator = hint_table.bits_required_for_fraction_numerator;
 
-    auto parse_int_entry = [&](u32 PageOffsetHintTableEntry::*field, u32 bit_size) -> ErrorOr<void> {
+    auto parse_int_entry = [&](u32 PageOffsetHintTableEntry::* field, u32 bit_size) -> ErrorOr<void> {
         if (bit_size <= 0)
             return {};
 
@@ -716,7 +716,7 @@ PDFErrorOr<Vector<DocumentParser::PageOffsetHintTableEntry>> DocumentParser::par
         return {};
     };
 
-    auto parse_vector_entry = [&](Vector<u32> PageOffsetHintTableEntry::*field, u32 bit_size) -> ErrorOr<void> {
+    auto parse_vector_entry = [&](Vector<u32> PageOffsetHintTableEntry::* field, u32 bit_size) -> ErrorOr<void> {
         if (bit_size <= 0)
             return {};
 

--- a/Userland/Libraries/LibShell/Parser.cpp
+++ b/Userland/Libraries/LibShell/Parser.cpp
@@ -18,10 +18,10 @@
 #define TRY_OR_THROW_PARSE_ERROR(expr) ({                                              \
     /* Ignore -Wshadow to allow nesting the macro. */                                  \
     AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                   \
-                         auto&& _value_or_error = expr;)                               \
+        auto&& _value_or_error = expr;)                                                \
     if (_value_or_error.is_error()) {                                                  \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                               \
-                             auto _error = _value_or_error.release_error();)           \
+            auto _error = _value_or_error.release_error();)                            \
         if (_error.is_errno() && _error.code() == ENOMEM)                              \
             return create<AST::SyntaxError>("OOM"_string);                             \
         return create<AST::SyntaxError>(MUST(String::formatted("Error: {}", _error))); \
@@ -32,11 +32,11 @@
 #define TRY_OR_RESOLVE_TO_ERROR_STRING(expr) ({                                   \
     /* Ignore -Wshadow to allow nesting the macro. */                             \
     AK_IGNORE_DIAGNOSTIC("-Wshadow",                                              \
-                         auto&& _value_or_error = expr;                           \
-                         String _string_value;)                                   \
+        auto&& _value_or_error = expr;                                            \
+        String _string_value;)                                                    \
     if (_value_or_error.is_error()) {                                             \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                          \
-                             auto _error = _value_or_error.release_error();)      \
+            auto _error = _value_or_error.release_error();)                       \
         if (_error.is_errno() && _error.code() == ENOMEM)                         \
             _string_value = "OOM"_string;                                         \
         else                                                                      \
@@ -45,16 +45,16 @@
     _value_or_error.is_error() ? _string_value : _value_or_error.release_value(); \
 })
 
-#define TRY_OR(expr, catch_expr) ({                                          \
-    /* Ignore -Wshadow to allow nesting the macro. */                        \
-    AK_IGNORE_DIAGNOSTIC("-Wshadow",                                         \
-                         auto&& _value_or_error = expr;)                     \
-    if (_value_or_error.is_error()) {                                        \
-        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                     \
-                             auto _error = _value_or_error.release_error();) \
-        catch_expr;                                                          \
-    }                                                                        \
-    _value_or_error.release_value();                                         \
+#define TRY_OR(expr, catch_expr) ({                         \
+    /* Ignore -Wshadow to allow nesting the macro. */       \
+    AK_IGNORE_DIAGNOSTIC("-Wshadow",                        \
+        auto&& _value_or_error = expr;)                     \
+    if (_value_or_error.is_error()) {                       \
+        AK_IGNORE_DIAGNOSTIC("-Wshadow",                    \
+            auto _error = _value_or_error.release_error();) \
+        catch_expr;                                         \
+    }                                                       \
+    _value_or_error.release_value();                        \
 })
 
 namespace Shell {

--- a/Userland/Libraries/LibShell/PosixParser.cpp
+++ b/Userland/Libraries/LibShell/PosixParser.cpp
@@ -13,10 +13,10 @@
 #define TRY_OR_THROW_PARSE_ERROR_AT(expr, position) ({                                                     \
     /* Ignore -Wshadow to allow nesting the macro. */                                                      \
     AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                                       \
-                         auto&& _value_or_error = expr;)                                                   \
+        auto&& _value_or_error = expr;)                                                                    \
     if (_value_or_error.is_error()) {                                                                      \
         AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                                   \
-                             auto _error = _value_or_error.release_error();)                               \
+            auto _error = _value_or_error.release_error();)                                                \
         if (_error.is_errno() && _error.code() == ENOMEM)                                                  \
             return make_ref_counted<AST::SyntaxError>(position, "OOM"_string);                             \
         return make_ref_counted<AST::SyntaxError>(position, MUST(String::formatted("Error: {}", _error))); \

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -158,12 +158,12 @@ struct Options {
         return typ { __VA_ARGS__ };          \
     }                                        \
     typ name = default_##name();             \
-    Options& set_##name(typ new_value)&      \
+    Options& set_##name(typ new_value) &     \
     {                                        \
         name = move(new_value);              \
         return *this;                        \
     }                                        \
-    Options&& set_##name(typ new_value)&&    \
+    Options&& set_##name(typ new_value) &&   \
     {                                        \
         name = move(new_value);              \
         return move(*this);                  \
@@ -190,8 +190,8 @@ struct Options {
     OPTION_WITH_DEFAULTS(bool, validate_certificates, true)
     OPTION_WITH_DEFAULTS(bool, allow_self_signed_certificates, false)
     OPTION_WITH_DEFAULTS(Optional<Vector<Certificate>>, root_certificates, )
-    OPTION_WITH_DEFAULTS(Function<void(AlertDescription)>, alert_handler, [](auto) {})
-    OPTION_WITH_DEFAULTS(Function<void()>, finish_callback, [] {})
+    OPTION_WITH_DEFAULTS(Function<void(AlertDescription)>, alert_handler, [](auto) { })
+    OPTION_WITH_DEFAULTS(Function<void()>, finish_callback, [] { })
     OPTION_WITH_DEFAULTS(Function<Vector<Certificate>()>, certificate_provider, [] { return Vector<Certificate> {}; })
     OPTION_WITH_DEFAULTS(bool, enable_extended_master_secret, true)
 

--- a/Userland/Libraries/LibWeb/CSS/ColumnCount.h
+++ b/Userland/Libraries/LibWeb/CSS/ColumnCount.h
@@ -34,7 +34,7 @@ private:
         , m_value(value)
     {
     }
-    ColumnCount() {};
+    ColumnCount() { }
 
     Type m_type { Type::Auto };
     Optional<int> m_value;

--- a/Userland/Libraries/LibWeb/CSS/Filter.h
+++ b/Userland/Libraries/LibWeb/CSS/Filter.h
@@ -16,7 +16,9 @@ class Filter {
 public:
     Filter() = default;
     Filter(FilterValueListStyleValue const& filter_value_list)
-        : m_filter_value_list { filter_value_list } {};
+        : m_filter_value_list { filter_value_list }
+    {
+    }
 
     static Filter make_none()
     {

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -32,8 +32,8 @@ public:
         return {};
     }
 
-    virtual void load_any_resources(DOM::Document&) {};
-    virtual void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const {};
+    virtual void load_any_resources(DOM::Document&) { }
+    virtual void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const { }
 
     virtual bool is_paintable() const = 0;
     virtual void paint(PaintContext& context, DevicePixelRect const& dest_rect, ImageRendering, Vector<Gfx::Path> const& clip_paths = {}) const = 0;

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -263,10 +263,10 @@ bool is_unknown_html_element(FlyString const& tag_name)
     if (tag_name.is_one_of(HTML::TagNames::applet, HTML::TagNames::bgsound, HTML::TagNames::blink, HTML::TagNames::isindex, HTML::TagNames::keygen, HTML::TagNames::multicol, HTML::TagNames::nextid, HTML::TagNames::spacer))
         return true;
 
-        // 2. If name is acronym, basefont, big, center, nobr, noembed, noframes, plaintext, rb, rtc, strike, or tt, then return HTMLElement.
-        // 3. If name is listing or xmp, then return HTMLPreElement.
-        // 4. Otherwise, if this specification defines an interface appropriate for the element type corresponding to the local name name, then return that interface.
-        // 5. If other applicable specifications define an appropriate interface for name, then return the interface they define.
+    // 2. If name is acronym, basefont, big, center, nobr, noembed, noframes, plaintext, rb, rtc, strike, or tt, then return HTMLElement.
+    // 3. If name is listing or xmp, then return HTMLPreElement.
+    // 4. Otherwise, if this specification defines an interface appropriate for the element type corresponding to the local name name, then return that interface.
+    // 5. If other applicable specifications define an appropriate interface for name, then return the interface they define.
 #define __ENUMERATE_HTML_TAG(name)        \
     if (tag_name == HTML::TagNames::name) \
         return false;

--- a/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -286,7 +286,7 @@ bool URLSearchParams::has(String const& name, Optional<String> const& value)
         if (!m_list.find_if([&name, &value](auto& entry) {
                        return entry.name == name && entry.value == value.value();
                    })
-                 .is_end()) {
+                .is_end()) {
             return true;
         }
     }
@@ -295,7 +295,7 @@ bool URLSearchParams::has(String const& name, Optional<String> const& value)
         if (!m_list.find_if([&name](auto& entry) {
                        return entry.name == name;
                    })
-                 .is_end()) {
+                .is_end()) {
             return true;
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -96,7 +96,7 @@ public:
     HTMLElement const& form_associated_element_to_html_element() const { return const_cast<FormAssociatedElement&>(*this).form_associated_element_to_html_element(); }
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset-control
-    virtual void reset_algorithm() {};
+    virtual void reset_algorithm() { }
 
     virtual void clear_algorithm();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1051,7 +1051,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::fetch_resource(URL::URL const& url_r
             // 5. Otherwise, incrementally read response's body given updateMedia, processEndOfMedia, an empty algorithm, and global.
 
             VERIFY(response->body());
-            auto empty_algorithm = JS::create_heap_function(heap(), [](JS::Value) {});
+            auto empty_algorithm = JS::create_heap_function(heap(), [](JS::Value) { });
 
             // FIXME: We are "fully" reading the response here, rather than "incrementally". Memory concerns aside, this should be okay for now as we are
             //        always setting byteRange to "entire resource". However, we should switch to incremental reads when that is implemented, and then

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -203,7 +203,7 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
         });
 
         VERIFY(response->body());
-        auto empty_algorithm = JS::create_heap_function(heap(), [](JS::Value) {});
+        auto empty_algorithm = JS::create_heap_function(heap(), [](JS::Value) { });
 
         response->body()->fully_read(realm, on_image_data_read, empty_algorithm, JS::NonnullGCPtr { global });
     };

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -672,8 +672,8 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
             //    that is synchronous navigation steps with a target navigable not contained in navigablesThatMustWaitBeforeHandlingSyncNavigation.
             //   2. Remove steps from traversable's session history traversal queue's algorithm set.
             for (auto entry = m_session_history_traversal_queue->first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation);
-                 entry;
-                 entry = m_session_history_traversal_queue->first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation)) {
+                entry;
+                entry = m_session_history_traversal_queue->first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation)) {
 
                 // 3. Set traversable's running nested apply history step to true.
                 m_running_nested_apply_history_step = true;

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -225,9 +225,9 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
 
         CSSPixelPoint offset = viewbox_offset_and_scale.offset;
         m_current_viewbox_transform = Gfx::AffineTransform { m_current_viewbox_transform }.multiply(Gfx::AffineTransform {}
-                                                                                                        .translate(offset.to_type<float>())
-                                                                                                        .scale(viewbox_offset_and_scale.scale_factor_x, viewbox_offset_and_scale.scale_factor_y)
-                                                                                                        .translate({ -viewbox->min_x, -viewbox->min_y }));
+                .translate(offset.to_type<float>())
+                .scale(viewbox_offset_and_scale.scale_factor_x, viewbox_offset_and_scale.scale_factor_y)
+                .translate({ -viewbox->min_x, -viewbox->min_y }));
     }
 
     if (svg_box_state.has_definite_width() && svg_box_state.has_definite_height()) {

--- a/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/AffineDisplayListPlayerCPU.h
@@ -45,12 +45,12 @@ public:
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
     bool needs_prepare_glyphs_texture() const override { return false; }
-    void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override {};
+    void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override { }
 
     virtual void prepare_to_execute(size_t) override { }
 
     bool needs_update_immutable_bitmap_texture_cache() const override { return false; }
-    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override {};
+    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override { }
 
     AffineDisplayListPlayerCPU(Gfx::Bitmap& bitmap, Gfx::AffineTransform transform, Gfx::IntRect clip);
     virtual ~AffineDisplayListPlayerCPU() override = default;

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerCPU.h
@@ -46,12 +46,12 @@ public:
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
     bool needs_prepare_glyphs_texture() const override { return false; }
-    void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override {};
+    void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override { }
 
     virtual void prepare_to_execute(size_t corner_clip_max_depth) override;
 
     bool needs_update_immutable_bitmap_texture_cache() const override { return false; }
-    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override {};
+    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override { }
 
     DisplayListPlayerCPU(Gfx::Bitmap& bitmap, bool enable_affine_command_executor = false);
     ~DisplayListPlayerCPU();

--- a/Userland/Libraries/LibWeb/Painting/PaintStyle.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintStyle.h
@@ -51,7 +51,7 @@ public:
     ReadonlySpan<ColorStop> color_stops() const { return m_color_stops; }
     Optional<float> repeat_length() const { return m_repeat_length; }
 
-    virtual ~SVGGradientPaintStyle() {};
+    virtual ~SVGGradientPaintStyle() = default;
 
 protected:
     Vector<ColorStop, 4> m_color_stops;

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -219,7 +219,7 @@ public:
 
     Gfx::AffineTransform compute_combined_css_transform() const;
 
-    virtual void resolve_paint_properties() {};
+    virtual void resolve_paint_properties() { }
 
 protected:
     explicit Paintable(Layout::Node const&);

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedTransformList.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedTransformList.cpp
@@ -20,7 +20,9 @@ JS::NonnullGCPtr<SVGAnimatedTransformList> SVGAnimatedTransformList::create(JS::
 SVGAnimatedTransformList::SVGAnimatedTransformList(JS::Realm& realm, JS::NonnullGCPtr<SVGTransformList> base_val, JS::NonnullGCPtr<SVGTransformList> anim_val)
     : PlatformObject(realm)
     , m_base_val(base_val)
-    , m_anim_val(anim_val) {};
+    , m_anim_val(anim_val)
+{
+}
 
 SVGAnimatedTransformList::~SVGAnimatedTransformList() = default;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTransform.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTransform.cpp
@@ -19,7 +19,9 @@ JS::NonnullGCPtr<SVGTransform> SVGTransform::create(JS::Realm& realm)
 }
 
 SVGTransform::SVGTransform(JS::Realm& realm)
-    : PlatformObject(realm) {};
+    : PlatformObject(realm)
+{
+}
 
 SVGTransform::~SVGTransform() = default;
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequestEventTarget.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequestEventTarget.h
@@ -24,7 +24,7 @@ class XMLHttpRequestEventTarget : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(XMLHttpRequestEventTarget, DOM::EventTarget);
 
 public:
-    virtual ~XMLHttpRequestEventTarget() override {};
+    virtual ~XMLHttpRequestEventTarget() override { }
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)       \

--- a/Userland/Libraries/LibWebView/ProcessManager.cpp
+++ b/Userland/Libraries/LibWebView/ProcessManager.cpp
@@ -71,7 +71,7 @@ void ProcessManager::initialize()
     // FIXME: Should we change this to call EventLoop::register_signal?
     //        Note that only EventLoopImplementationUnix has a working register_signal
 
-    struct sigaction action { };
+    struct sigaction action {};
     action.sa_flags = SA_RESTART;
     action.sa_sigaction = [](int, auto*, auto) {
         s_received_sigchld = 1;

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -31,10 +31,10 @@ public:
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
     virtual Web::CSS::PreferredContrast preferred_contrast() const override;
     virtual Web::CSS::PreferredMotion preferred_motion() const override;
-    virtual void paint_next_frame() override {};
+    virtual void paint_next_frame() override { }
     virtual void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;
-    virtual void schedule_repaint() override {};
+    virtual void schedule_repaint() override { }
     virtual bool is_ready_to_paint() const override { return true; }
     virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }
 

--- a/Userland/Services/WindowServer/Overlays.h
+++ b/Userland/Services/WindowServer/Overlays.h
@@ -57,7 +57,7 @@ protected:
 
     void set_rect(Gfx::IntRect const&);
 
-    virtual void rect_changed(Gfx::IntRect const&) {};
+    virtual void rect_changed(Gfx::IntRect const&) { }
 
 private:
     [[nodiscard]] bool apply_render_rect()

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -32,8 +32,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         s_shell->kill_job(s_shell->current_job(), SIGWINCH);
     });
 
-    Core::EventLoop::register_signal(SIGTTIN, [](int) {});
-    Core::EventLoop::register_signal(SIGTTOU, [](int) {});
+    Core::EventLoop::register_signal(SIGTTIN, [](int) { });
+    Core::EventLoop::register_signal(SIGTTOU, [](int) { });
 
     Core::EventLoop::register_signal(SIGHUP, [](int) {
         for (auto& it : s_shell->jobs)

--- a/Userland/Utilities/expr.cpp
+++ b/Userland/Utilities/expr.cpp
@@ -75,7 +75,7 @@ public:
     {
     }
 
-    virtual ~ValueExpression() {};
+    virtual ~ValueExpression() { }
 
 private:
     virtual bool truth() const override

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -56,8 +56,7 @@ struct FileData {
     // The file's basename, relative to the directory.
     char const* basename { nullptr };
     // Optionally, cached information as returned by stat/lstat/fstatat.
-    struct stat stat {
-    };
+    struct stat stat {};
     bool stat_is_valid : 1 { false };
     // File type as returned from readdir(), or DT_UNKNOWN.
     unsigned char d_type { DT_UNKNOWN };

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -39,8 +39,7 @@ struct FileMetadata {
     ByteString name;
     ByteString path;
     ino_t raw_inode_number;
-    struct stat stat {
-    };
+    struct stat stat {};
 };
 
 enum class FieldToSortBy {
@@ -429,8 +428,7 @@ static bool print_filesystem_metadata_object(FileMetadata const& file)
 static int do_file_system_object_long(ByteString const& path)
 {
     if (flag_list_directories_only) {
-        struct stat stat {
-        };
+        struct stat stat {};
         int rc = lstat(path.characters(), &stat);
         if (rc < 0)
             perror("lstat");
@@ -452,8 +450,7 @@ static int do_file_system_object_long(ByteString const& path)
     if (di.has_error()) {
         auto error = di.error();
         if (error.code() == ENOTDIR) {
-            struct stat stat {
-            };
+            struct stat stat {};
             int rc = lstat(path.characters(), &stat);
             if (rc < 0)
                 perror("lstat");

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -27,7 +27,7 @@
 class SelectableLayover final : public GUI::Widget {
     C_OBJECT(SelectableLayover)
 public:
-    virtual ~SelectableLayover() override {};
+    virtual ~SelectableLayover() override = default;
 
     Gfx::IntRect region() const
     {


### PR DESCRIPTION
These lines would change with the new clang-format, so we might as well
use the preferred `= default`.